### PR TITLE
[DP-61] fix: 상품 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/dapanda/product/dto/WifiSummary.java
+++ b/src/main/java/com/dapanda/product/dto/WifiSummary.java
@@ -15,14 +15,14 @@ public class WifiSummary extends ProductSummary {
 	private double distanceKm;
 
 	public WifiSummary(Long id, int price, Long itemId, String memberName, String title,
-			double latitude, double longitude, String imageUrl, double averageRate,
+			String imageUrl, double latitude, double longitude, double averageRate,
 			double distanceKm) {
 
 		super(id, price, itemId, memberName);
 		this.title = title;
+		this.imageUrl = imageUrl;
 		this.latitude = latitude;
 		this.longitude = longitude;
-		this.imageUrl = imageUrl;
 		this.averageRate = averageRate;
 		this.distanceKm = distanceKm;
 	}

--- a/src/main/java/com/dapanda/product/entity/ProductImage.java
+++ b/src/main/java/com/dapanda/product/entity/ProductImage.java
@@ -1,0 +1,38 @@
+package com.dapanda.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String imageUrl;
+
+	private int priority;
+
+	private Long wifiId;
+
+	public static ProductImage of(String imageUrl, int priority, Long wifiId) {
+
+		return ProductImage.builder()
+				.imageUrl(imageUrl)
+				.priority(priority)
+				.wifiId(wifiId)
+				.build();
+	}
+}

--- a/src/main/java/com/dapanda/product/entity/Wifi.java
+++ b/src/main/java/com/dapanda/product/entity/Wifi.java
@@ -30,21 +30,18 @@ public class Wifi {
 
 	private double longitude; // 경도
 
-	private String imageUrl;
-
 	private LocalDateTime startTime;
 
 	private LocalDateTime endTime;
 
 	public static Wifi of(String title, String content, double latitude, double longitude,
-			String imageUrl, LocalDateTime startTime, LocalDateTime endTime) {
+			LocalDateTime startTime, LocalDateTime endTime) {
 
 		return Wifi.builder()
 				.title(title)
 				.content(content)
 				.latitude(latitude)
 				.longitude(longitude)
-				.imageUrl(imageUrl)
 				.startTime(startTime)
 				.endTime(endTime)
 				.build();

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -1,24 +1,25 @@
 package com.dapanda.product.repository;
 
+import static com.dapanda.review.entity.QReview.review;
+
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
 import com.dapanda.product.entity.ProductSortOption;
 import com.dapanda.product.entity.QMobileData;
 import com.dapanda.product.entity.QProduct;
+import com.dapanda.product.entity.QProductImage;
 import com.dapanda.product.entity.QWifi;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static com.dapanda.review.entity.QReview.review;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -87,6 +88,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
 		QProduct product = QProduct.product;
 		QWifi wifi = QWifi.wifi;
+		QProductImage productImage = QProductImage.productImage;
+		QProductImage productImageSub = new QProductImage("productImageSub");
 
 		LocalDateTime now = LocalDateTime.now();
 
@@ -102,9 +105,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.itemId,
 						product.member.name,
 						wifi.title,
+						Expressions.stringTemplate("MIN({0})", productImage.imageUrl),
 						wifi.latitude,
 						wifi.longitude,
-						wifi.imageUrl,
 						review.rating.avg().coalesce(DEFAULT_RATING),
 						distance.divide(METER_TO_KILOMETER)
 				))
@@ -112,6 +115,15 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.groupBy(product.id)
 				.join(wifi).on(wifi.id.eq(product.itemId))
 				.leftJoin(review).on(review.productId.eq(product.id))
+				.leftJoin(productImage).on(
+						productImage.wifiId.eq(wifi.id)
+								.and(productImage.priority.eq(
+										JPAExpressions
+												.select(productImageSub.priority.min())
+												.from(productImageSub)
+												.where(productImageSub.wifiId.eq(wifi.id))
+								))
+				)
 				.where(
 						gtCursorId(cursorId, product),
 						isOpenNow(isOpen, wifi, now)

--- a/src/main/java/com/dapanda/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductImageRepository.java
@@ -1,0 +1,10 @@
+package com.dapanda.product.repository;
+
+import com.dapanda.product.entity.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+}

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -1,5 +1,14 @@
 package com.dapanda.product.controller;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.dapanda.TestConfig;
 import com.dapanda.common.exception.ResultCode;
 import com.dapanda.member.entity.Member;
@@ -7,13 +16,22 @@ import com.dapanda.member.entity.MemberFixture;
 import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.product.dto.request.MobileDataCursorRequest;
 import com.dapanda.product.dto.request.WifiCursorRequest;
-import com.dapanda.product.entity.*;
+import com.dapanda.product.entity.MobileData;
+import com.dapanda.product.entity.MobileDataFixture;
+import com.dapanda.product.entity.Product;
+import com.dapanda.product.entity.ProductFixture;
+import com.dapanda.product.entity.ProductImage;
+import com.dapanda.product.entity.ProductImageFixture;
+import com.dapanda.product.entity.Wifi;
+import com.dapanda.product.entity.WifiFixture;
 import com.dapanda.product.repository.MobileDataRepository;
+import com.dapanda.product.repository.ProductImageRepository;
 import com.dapanda.product.repository.ProductRepository;
 import com.dapanda.product.repository.WifiRepository;
-import com.dapanda.product.service.ProductService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,18 +47,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -73,9 +80,10 @@ class ProductControllerTest {
 	@Autowired
 	private WifiRepository wifiRepository;
 
-	private MockMvc mockMvc;
 	@Autowired
-	private ProductService productService;
+	private ProductImageRepository productImageRepository;
+
+	private MockMvc mockMvc;
 
 	@BeforeEach
 	void restDocsSetUp(RestDocumentationContextProvider restDocumentation) {
@@ -268,6 +276,12 @@ class ProductControllerTest {
 						LocalDateTime.of(2025, 7, 14, 18, 0));
 				wifiRepository.saveAll(List.of(wifi1, wifi2, wifi3));
 
+				ProductImage productImage1 = ProductImageFixture.createProductImage("imageUrl1", 1,
+						wifi1.getId());
+				ProductImage productImage2 = ProductImageFixture.createProductImage("imageUrl2", 2,
+						wifi2.getId());
+				productImageRepository.saveAll(List.of(productImage1, productImage2));
+
 				Product product1 = ProductFixture.createWifiProduct(3000, wifi1.getId(), member);
 				Product product2 = ProductFixture.createWifiProduct(4000, wifi2.getId(), member);
 				Product product3 = ProductFixture.createWifiProduct(5000, wifi3.getId(), member);
@@ -311,10 +325,11 @@ class ProductControllerTest {
 										fieldWithPath("data.data[].memberName").description(
 												"등록한 회원 이름"),
 										fieldWithPath("data.data[].title").description("게시물 제목"),
+										fieldWithPath("data.data[].imageUrl").description(
+												"대표 이미지 URL").optional(),
 										fieldWithPath("data.data[].latitude").description("위도"),
 										fieldWithPath("data.data[].longitude").description("경도"),
-										fieldWithPath("data.data[].imageUrl").description(
-												"이미지 URL"),
+
 										fieldWithPath("data.data[].averageRate").description(
 												"평균 평점"),
 										fieldWithPath("data.data[].distanceKm").description(

--- a/src/test/java/com/dapanda/product/entity/ProductImageFixture.java
+++ b/src/test/java/com/dapanda/product/entity/ProductImageFixture.java
@@ -1,0 +1,13 @@
+package com.dapanda.product.entity;
+
+public class ProductImageFixture {
+
+	public static ProductImage createProductImage(String imageUrl, int priority, Long wifiId) {
+
+		return ProductImage.of(
+				imageUrl,
+				priority,
+				wifiId
+		);
+	}
+}

--- a/src/test/java/com/dapanda/product/entity/WifiFixture.java
+++ b/src/test/java/com/dapanda/product/entity/WifiFixture.java
@@ -14,7 +14,6 @@ public class WifiFixture {
 				content,
 				latitude,
 				longitude,
-				"imageUrl",
 				startTime,
 				endTime
 		);
@@ -27,7 +26,6 @@ public class WifiFixture {
 				"선릉역 2번출구 앞 카페 와이파이",
 				30.1,
 				126.3,
-				"imageUrl",
 				LocalDateTime.of(2025, 7, 13, 10, 0),
 				LocalDateTime.of(2025, 7, 13, 22, 0)
 		);
@@ -48,9 +46,9 @@ public class WifiFixture {
 				itemId,
 				memberName,
 				title,
+				"imageUrl",
 				latitude,
 				longitude,
-				"imageUrl",
 				averageRate,
 				distanceKm
 		);

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -221,31 +221,6 @@ class ProductServiceTest {
 			class Success {
 
 				@Test
-				@DisplayName("RECENT 정렬로 와이파이 상품 목록 조회를 성공한다")
-				void findWifiSortedByRecent() {
-
-					// given
-					List<WifiSummary> summaries = new ArrayList<>();
-					for (int i = 1; i <= 3; i++) {
-						summaries.add(
-								WifiFixture.createWifiSummary((long) i, 1000, (long) i,
-										"회원" + i, "상품제목" + i, 37.0 + i, 127.0 + i, i * 10.0, i));
-					}
-					CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
-							CursorPageResponse.PageInfo.of(3L, false, 3));
-
-					given(productRepository.findWifiByCursor(null, 3, ProductSortOption.RECENT,
-							true, 37.0, 127.0)).willReturn(response);
-
-					// when
-					CursorPageResponse<WifiSummary> result = productService.findWifiByCursor(
-							new WifiCursorRequest(null, 3, "RECENT", true, 37.0, 127.0));
-
-					// then
-					assertThat(result.getData()).hasSize(3);
-				}
-
-				@Test
 				@DisplayName("PRICE_ASC 정렬로 와이파이 상품 목록 조회를 성공한다")
 				void findWifiSortedByPriceAsc() {
 
@@ -346,10 +321,10 @@ class ProductServiceTest {
 					// given
 					List<WifiSummary> summaries = new ArrayList<>();
 					summaries.add(
-							new WifiSummary(1L, 1000, 1L, "회원1", "상품제목1", 37.0, 127.0, "imageUrl",
+							new WifiSummary(1L, 1000, 1L, "회원1", "상품제목1", "imageUrl", 37.0, 127.0,
 									5, 5));
 					summaries.add(
-							new WifiSummary(2L, 2000, 2L, "회원2", "상품제목2", 37.1, 127.1, "imageUrl",
+							new WifiSummary(2L, 2000, 2L, "회원2", "상품제목2", "imageUrl", 37.1, 127.1,
 									10, 10));
 					CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
 							CursorPageResponse.PageInfo.of(2L, false, 2));


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 상품 등록 시 이미지를 3개까지 넣을 수 있음에 따라 `ProductImage` 엔티티 추가 및 기존 와이파이 상품 목록 조회 기능 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #44 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?