### PR TITLE
[DP-111] fix: 데이터 상품 상세 조회 응답에 splitType 반환하도록 수정

### DIFF
--- a/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
@@ -17,5 +17,6 @@ public class MobileDataInfoResponse {
 	private int pricePer100MB;
 	private double averageRate;
 	private int reviewCount;
+	private boolean splitType;
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -178,6 +178,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						mobileData.pricePer100MB,
 						review.rating.avg().coalesce(DEFAULT_RATING),
 						review.rating.count().intValue(),
+						mobileData.isSplitType,
 						product.updatedAt
 				))
 				.from(product)

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -313,7 +313,7 @@ class ProductControllerTest {
 				java.util.Map<String, Object> map = objectMapper.convertValue(incompleteRequest,
 						java.util.Map.class);
 				map.remove("price");
-				
+
 				String invalidJson = objectMapper.writeValueAsString(map);
 
 				mockMvc.perform(MockMvcRequestBuilders.post("/api/products/mobile-data")
@@ -727,6 +727,7 @@ class ProductControllerTest {
 						.andExpect(jsonPath("$.data.pricePer100MB").value(PRICE_PER_100MB_300))
 						.andExpect(jsonPath("$.data.averageRate").exists())
 						.andExpect(jsonPath("$.data.reviewCount").exists())
+						.andExpect(jsonPath("$.data.splitType").exists())
 						.andExpect(jsonPath("$.data.updatedAt").exists())
 						.andDo(document("product/get-mobile-data-info",
 								responseFields(
@@ -744,6 +745,7 @@ class ProductControllerTest {
 												"100MB 당 가격"),
 										fieldWithPath("data.averageRate").description("평균 별점"),
 										fieldWithPath("data.reviewCount").description("리뷰 수"),
+										fieldWithPath("data.splitType").description("분할 여부"),
 										fieldWithPath("data.updatedAt").description("수정된 시간")
 								))
 						);

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -550,8 +550,8 @@ class ProductServiceTest {
 						REMAIN_AMOUNT_1, PRICE_PER_100MB_300);
 				MobileDataInfoResponse expectedResponse = new MobileDataInfoResponse(PRODUCT_ID,
 						mobileData.getId(), PRICE_3000, member.getId(), member.getName(),
-						REMAIN_AMOUNT_1,
-						PRICE_PER_100MB_300, AVERAGE_RATE, REVIEW_COUNT, UPDATED_AT);
+						REMAIN_AMOUNT_1, PRICE_PER_100MB_300, AVERAGE_RATE, REVIEW_COUNT, false,
+						UPDATED_AT);
 
 				given(productRepository.existsById(PRODUCT_ID))
 						.willReturn(true);


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 상품 상세 조회 응답에 splitType 반환하도록 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #98 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?