### PR TITLE
[DP-128] feat: 캐시 조회 기능

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -79,6 +79,25 @@ DaPanda 서비스의 REST API 문서입니다.
 [[resources]]
 == API 목록
 
+[[resources-member]]
+=== 회원
+
+==== 캐시 조회
+
+`GET` 회원이 보유한 캐시 조회
+
+===== 요청
+
+include::{snippets}/member/get-cash/http-request.adoc[]
+
+===== 응답
+
+include::{snippets}/member/get-cash/http-response.adoc[]
+
+===== 응답 필드
+
+include::{snippets}/member/get-cash/response-fields.adoc[]
+
 === 채팅
 
 ==== WebSocket 프로토콜

--- a/src/main/java/com/dapanda/member/MemberController.java
+++ b/src/main/java/com/dapanda/member/MemberController.java
@@ -1,0 +1,26 @@
+package com.dapanda.member;
+
+import com.dapanda.auth.entity.CustomUserDetails;
+import com.dapanda.common.exception.CommonResponse;
+import com.dapanda.member.dto.response.FindCashResponse;
+import com.dapanda.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@GetMapping("/members/cash")
+	public CommonResponse<FindCashResponse> getCash(
+			@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		return CommonResponse.success(memberService.findCash(userDetails.getId()));
+	}
+}

--- a/src/main/java/com/dapanda/member/controller/MemberController.java
+++ b/src/main/java/com/dapanda/member/controller/MemberController.java
@@ -1,4 +1,4 @@
-package com.dapanda.member;
+package com.dapanda.member.controller;
 
 import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.common.exception.CommonResponse;

--- a/src/main/java/com/dapanda/member/dto/response/FindCashResponse.java
+++ b/src/main/java/com/dapanda/member/dto/response/FindCashResponse.java
@@ -1,0 +1,23 @@
+package com.dapanda.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FindCashResponse {
+
+	private int cash;
+
+	public static FindCashResponse of(int cash) {
+
+		return FindCashResponse.builder()
+				.cash(cash)
+				.build();
+	}
+}

--- a/src/main/java/com/dapanda/member/entity/Member.java
+++ b/src/main/java/com/dapanda/member/entity/Member.java
@@ -60,9 +60,9 @@ public class Member extends BaseEntity {
 
 	private int reportedCount;
 
-	private int reviewCount = 0;
+	private int reviewCount;
 
-	private float averageRating = 0.0f;
+	private float averageRating;
 
 	public static Member ofOAuthMember(String email, String name,
 			OAuthProvider provider, MemberRole role) {

--- a/src/main/java/com/dapanda/member/service/MemberService.java
+++ b/src/main/java/com/dapanda/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.dapanda.common.exception.GlobalException;
 import com.dapanda.common.exception.ResultCode;
 import com.dapanda.jwt.JwtPrinciple;
 import com.dapanda.jwt.JwtTokenProvider;
+import com.dapanda.member.dto.response.FindCashResponse;
 import com.dapanda.member.entity.Member;
 import com.dapanda.member.entity.MemberRole;
 import com.dapanda.member.repository.MemberRepository;
@@ -117,5 +118,12 @@ public class MemberService {
 
 		return memberRepository.findByEmailAndProvider(email, provider)
 				.orElseThrow(() -> new GlobalException(ResultCode.MEMBER_NOT_FOUND));
+	}
+
+	public FindCashResponse findCash(Long memberId) {
+
+		int cash = memberRepository.findById(memberId).orElseThrow().getCash();
+
+		return FindCashResponse.of(cash);
 	}
 }

--- a/src/test/java/com/dapanda/member/MemberControllerTest.java
+++ b/src/test/java/com/dapanda/member/MemberControllerTest.java
@@ -1,0 +1,121 @@
+package com.dapanda.member;
+
+import static com.dapanda.TestConstants.Member.CASH_5000;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dapanda.TestConfig;
+import com.dapanda.auth.entity.CustomUserDetails;
+import com.dapanda.common.exception.ResultCode;
+import com.dapanda.member.entity.Member;
+import com.dapanda.member.entity.MemberFixture;
+import com.dapanda.member.repository.MemberRepository;
+import com.dapanda.member.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+@ExtendWith(RestDocumentationExtension.class)
+@DisplayName("회원 컨트롤러 테스트")
+class MemberControllerTest {
+
+	@Autowired
+	private WebApplicationContext context;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	@Autowired
+	private EntityManager entityManager;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private MemberService memberService;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void restDocsSetUp(RestDocumentationContextProvider restDocumentation) {
+
+		this.mockMvc = TestConfig.createMockMvc(context, restDocumentation);
+
+		cleanupDatabase();
+	}
+
+	private void cleanupDatabase() {
+
+		entityManager.clear();
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+		jdbcTemplate.execute("TRUNCATE TABLE member");
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+	}
+
+	@Nested
+	@DisplayName("캐시 조회 API")
+	class MobileDataFullDefaultPurchase {
+
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
+
+			@Test
+			@DisplayName("데이터 통합 상품 일반 구매를 성공한다")
+			void findCash() throws Exception {
+
+				// given
+				Member member = MemberFixture.createMember1();
+				ReflectionTestUtils.setField(member, "cash", CASH_5000);
+				memberRepository.save(member);
+
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
+				// when & then
+				mockMvc.perform(get("/api/members/cash")
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								)))
+						)
+						.andExpect(status().isOk())
+						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
+						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
+						.andExpect(jsonPath("$.data.cash").value(CASH_5000))
+						.andDo(document("member/get-cash",
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("처리 결과 메시지"),
+										fieldWithPath("data").description("응답 데이터 (에러시 반환되지 않음)"),
+										fieldWithPath("data.cash").description("회원이 보유한 캐시")
+								))
+						);
+			}
+		}
+	}
+}

--- a/src/test/java/com/dapanda/member/MemberControllerTest.java
+++ b/src/test/java/com/dapanda/member/MemberControllerTest.java
@@ -1,0 +1,121 @@
+package com.dapanda.member;
+
+import static com.dapanda.TestConstants.Member.CASH_5000;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dapanda.TestConfig;
+import com.dapanda.auth.entity.CustomUserDetails;
+import com.dapanda.common.exception.ResultCode;
+import com.dapanda.member.entity.Member;
+import com.dapanda.member.entity.MemberFixture;
+import com.dapanda.member.repository.MemberRepository;
+import com.dapanda.member.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+@ExtendWith(RestDocumentationExtension.class)
+@DisplayName("회원 컨트롤러 테스트")
+class MemberControllerTest {
+
+	@Autowired
+	private WebApplicationContext context;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	@Autowired
+	private EntityManager entityManager;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private MemberService memberService;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void restDocsSetUp(RestDocumentationContextProvider restDocumentation) {
+
+		this.mockMvc = TestConfig.createMockMvc(context, restDocumentation);
+
+		cleanupDatabase();
+	}
+
+	private void cleanupDatabase() {
+
+		entityManager.clear();
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+		jdbcTemplate.execute("TRUNCATE TABLE member");
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+	}
+
+	@Nested
+	@DisplayName("캐시 조회")
+	class MobileDataFullDefaultPurchase {
+
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
+
+			@Test
+			@DisplayName("데이터 통합 상품 일반 구매를 성공한다")
+			void findCash() throws Exception {
+
+				// given
+				Member member = MemberFixture.createMember1();
+				ReflectionTestUtils.setField(member, "cash", CASH_5000);
+				memberRepository.save(member);
+
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
+				// when & then
+				mockMvc.perform(get("/api/members/cash")
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								)))
+						)
+						.andExpect(status().isOk())
+						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
+						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
+						.andExpect(jsonPath("$.data.cash").value(CASH_5000))
+						.andDo(document("member/get-cash",
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("처리 결과 메시지"),
+										fieldWithPath("data").description("응답 데이터 (에러시 반환되지 않음)"),
+										fieldWithPath("data.cash").description("회원이 보유한 캐시")
+								))
+						);
+			}
+		}
+	}
+}

--- a/src/test/java/com/dapanda/member/service/MemberServiceBeanTest.java
+++ b/src/test/java/com/dapanda/member/service/MemberServiceBeanTest.java
@@ -1,0 +1,231 @@
+package com.dapanda.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.dapanda.auth.dto.request.LoginRequest;
+import com.dapanda.auth.dto.request.SignupRequest;
+import com.dapanda.auth.dto.response.LoginResponse;
+import com.dapanda.auth.dto.response.SignupResponse;
+import com.dapanda.auth.entity.OAuthProvider;
+import com.dapanda.common.exception.GlobalException;
+import com.dapanda.common.exception.ResultCode;
+import com.dapanda.jwt.JwtTokenProvider;
+import com.dapanda.member.entity.Member;
+import com.dapanda.member.entity.MemberRole;
+import com.dapanda.member.repository.MemberRepository;
+import com.dapanda.refreshToken.repository.RefreshTokenRepository;
+import com.dapanda.refreshToken.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@DisplayName("Member 서비스 테스트")
+class MemberServiceBeanTest {
+
+	static final String EMAIL = "user@aaa.com";
+	static final String PASSWORD = "P@ssword1";
+	static final String NAME = "홍길동";
+	static final MemberRole ROLE = MemberRole.ROLE_MEMBER;
+
+	@Autowired
+	MemberService memberService;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	PasswordEncoder passwordEncoder;
+	@Autowired
+	RefreshTokenService refreshTokenService;
+	@Autowired
+	JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	RefreshTokenRepository refreshTokenRepository;
+
+	@BeforeEach
+	void setUp() {
+
+		refreshTokenRepository.deleteAll();
+		memberRepository.deleteAll();
+	}
+
+	@Nested
+	@DisplayName("회원가입(registerUser)")
+	class RegisterUserTest {
+
+		@Test
+		@DisplayName("정상적으로 회원가입된다")
+		void registerUser_success() {
+
+			SignupRequest request = new SignupRequest(EMAIL, PASSWORD, NAME);
+
+			SignupResponse response = memberService.registerUser(request);
+
+			assertThat(response).isNotNull();
+			assertThat(response.getMessage()).contains("완료");
+			assertThat(memberRepository.findByEmail(EMAIL)).isPresent();
+		}
+
+		@Test
+		@DisplayName("중복 이메일이면 예외 발생")
+		void duplicateEmail() {
+
+			memberRepository.save(Member.ofLocalMember(
+					EMAIL,
+					NAME,
+					passwordEncoder.encode(PASSWORD),
+					OAuthProvider.LOCAL,
+					ROLE
+			));
+
+			SignupRequest request = new SignupRequest(EMAIL, PASSWORD, "다른이름");
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.registerUser(request));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.DUPLICATE_EMAIL);
+		}
+
+		@Test
+		@DisplayName("중복 닉네임이면 예외 발생")
+		void duplicateName() {
+
+			memberRepository.save(Member.ofLocalMember(
+					EMAIL,
+					NAME,
+					passwordEncoder.encode(PASSWORD),
+					OAuthProvider.LOCAL,
+					ROLE));
+
+			SignupRequest request = new SignupRequest("diff@aaa.com", PASSWORD, NAME);
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.registerUser(request));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.DUPLICATE_USERNAME);
+		}
+
+		@Test
+		@DisplayName("이메일 형식이 아니면 예외 발생")
+		void invalidEmail() {
+
+			SignupRequest request = new SignupRequest("invalid-email", PASSWORD, NAME);
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.registerUser(request));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_EMAIL_FORMAT);
+		}
+
+		@Test
+		@DisplayName("닉네임 길이가 5자 이상이면 예외 발생")
+		void nameTooLong() {
+
+			SignupRequest request = new SignupRequest("ok@ok.com", PASSWORD, "긴이름123");
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.registerUser(request));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_MEMBERNAME_FORMAT);
+		}
+
+		@Test
+		@DisplayName("비밀번호 보안 기준 미달이면 예외 발생")
+		void weakPassword() {
+
+			SignupRequest request = new SignupRequest("ok@ok.com", "1234", NAME);
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.registerUser(request));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.WEAK_PASSWORD);
+		}
+	}
+
+	@Nested
+	@DisplayName("로그인(login)")
+	class LoginTest {
+
+		@BeforeEach
+		void setupMember() {
+
+			Member member = Member.ofLocalMember(
+					EMAIL,
+					NAME,
+					passwordEncoder.encode(PASSWORD),
+					OAuthProvider.LOCAL,
+					ROLE);
+			memberRepository.save(member);
+		}
+
+		@Test
+		@DisplayName("정상적으로 로그인된다")
+		void login_success() {
+
+			LoginRequest request = new LoginRequest(EMAIL, PASSWORD);
+			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+			LoginResponse loginResponse = memberService.login(request, response);
+
+			assertThat(loginResponse).isNotNull();
+			assertThat(loginResponse.getName()).isEqualTo(NAME);
+			assertThat(loginResponse.getMessage()).contains("성공");
+		}
+
+		@Test
+		@DisplayName("회원이 없으면 예외 발생")
+		void memberNotFound() {
+
+			LoginRequest request = new LoginRequest("none@aaa.com", PASSWORD);
+			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.login(request, response));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.MEMBER_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("비밀번호 불일치 시 예외 발생")
+		void invalidPassword() {
+
+			LoginRequest request = new LoginRequest(EMAIL, "Wrong123");
+			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.login(request, response));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_PASSWORD);
+		}
+	}
+
+	@Nested
+	@DisplayName("findUserByEmailAndProvider")
+	class FindUserByEmailAndProviderTest {
+
+		@Test
+		@DisplayName("정상적으로 찾을 수 있다")
+		void find_success() {
+
+			Member member = Member.ofLocalMember(
+					EMAIL,
+					NAME,
+					passwordEncoder.encode(PASSWORD),
+					OAuthProvider.LOCAL,
+					ROLE);
+			memberRepository.save(member);
+
+			Member found = memberService.findUserByEmailAndProvider(EMAIL, OAuthProvider.LOCAL);
+			assertThat(found).isNotNull();
+			assertThat(found.getEmail()).isEqualTo(EMAIL);
+		}
+
+		@Test
+		@DisplayName("없는 경우 예외")
+		void not_found() {
+
+			GlobalException ex = assertThrows(GlobalException.class,
+					() -> memberService.findUserByEmailAndProvider("none@none.com",
+							OAuthProvider.LOCAL));
+			assertThat(ex.getResultCode()).isEqualTo(ResultCode.MEMBER_NOT_FOUND);
+		}
+	}
+}

--- a/src/test/java/com/dapanda/member/service/MemberServiceTest.java
+++ b/src/test/java/com/dapanda/member/service/MemberServiceTest.java
@@ -1,231 +1,58 @@
 package com.dapanda.member.service;
 
-import com.dapanda.auth.dto.request.LoginRequest;
-import com.dapanda.auth.dto.request.SignupRequest;
-import com.dapanda.auth.dto.response.LoginResponse;
-import com.dapanda.auth.dto.response.SignupResponse;
-import com.dapanda.auth.entity.OAuthProvider;
-import com.dapanda.common.exception.GlobalException;
-import com.dapanda.common.exception.ResultCode;
-import com.dapanda.jwt.JwtTokenProvider;
+import static com.dapanda.TestConstants.Member.CASH_5000;
+import static com.dapanda.TestConstants.Member.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.dapanda.member.dto.response.FindCashResponse;
 import com.dapanda.member.entity.Member;
-import com.dapanda.member.entity.MemberRole;
+import com.dapanda.member.entity.MemberFixture;
 import com.dapanda.member.repository.MemberRepository;
-import com.dapanda.refreshToken.repository.RefreshTokenRepository;
-import com.dapanda.refreshToken.service.RefreshTokenService;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-@DisplayName("Member 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+@DisplayName("회원 서비스 테스트")
 class MemberServiceTest {
 
-	static final String EMAIL = "user@aaa.com";
-	static final String PASSWORD = "P@ssword1";
-	static final String NAME = "홍길동";
-	static final MemberRole ROLE = MemberRole.ROLE_MEMBER;
+	@Mock
+	private MemberRepository memberRepository;
 
-	@Autowired
-	MemberService memberService;
-	@Autowired
-	MemberRepository memberRepository;
-	@Autowired
-	PasswordEncoder passwordEncoder;
-	@Autowired
-	RefreshTokenService refreshTokenService;
-	@Autowired
-	JwtTokenProvider jwtTokenProvider;
-	@Autowired
-	RefreshTokenRepository refreshTokenRepository;
-
-	@BeforeEach
-	void setUp() {
-
-		refreshTokenRepository.deleteAll();
-		memberRepository.deleteAll();
-	}
+	@InjectMocks
+	private MemberService memberService;
 
 	@Nested
-	@DisplayName("회원가입(registerUser)")
-	class RegisterUserTest {
+	@DisplayName("캐시 조회")
+	class MobileDataFullDefaultPurchase {
 
-		@Test
-		@DisplayName("정상적으로 회원가입된다")
-		void registerUser_success() {
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
 
-			SignupRequest request = new SignupRequest(EMAIL, PASSWORD, NAME);
+			@Test
+			@DisplayName("데이터 통합 상품 일반 구매를 성공한다")
+			void findCash() throws Exception {
 
-			SignupResponse response = memberService.registerUser(request);
+				// given
+				Member member = MemberFixture.createMember1WithId(MEMBER_ID);
+				ReflectionTestUtils.setField(member, "cash", CASH_5000);
 
-			assertThat(response).isNotNull();
-			assertThat(response.getMessage()).contains("완료");
-			assertThat(memberRepository.findByEmail(EMAIL)).isPresent();
-		}
+				given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(member));
 
-		@Test
-		@DisplayName("중복 이메일이면 예외 발생")
-		void duplicateEmail() {
+				// when
+				FindCashResponse response = memberService.findCash(MEMBER_ID);
 
-			memberRepository.save(Member.ofLocalMember(
-					EMAIL,
-					NAME,
-					passwordEncoder.encode(PASSWORD),
-					OAuthProvider.LOCAL,
-					ROLE
-			));
-
-			SignupRequest request = new SignupRequest(EMAIL, PASSWORD, "다른이름");
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.registerUser(request));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.DUPLICATE_EMAIL);
-		}
-
-		@Test
-		@DisplayName("중복 닉네임이면 예외 발생")
-		void duplicateName() {
-
-			memberRepository.save(Member.ofLocalMember(
-					EMAIL,
-					NAME,
-					passwordEncoder.encode(PASSWORD),
-					OAuthProvider.LOCAL,
-					ROLE));
-
-			SignupRequest request = new SignupRequest("diff@aaa.com", PASSWORD, NAME);
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.registerUser(request));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.DUPLICATE_USERNAME);
-		}
-
-		@Test
-		@DisplayName("이메일 형식이 아니면 예외 발생")
-		void invalidEmail() {
-
-			SignupRequest request = new SignupRequest("invalid-email", PASSWORD, NAME);
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.registerUser(request));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_EMAIL_FORMAT);
-		}
-
-		@Test
-		@DisplayName("닉네임 길이가 5자 이상이면 예외 발생")
-		void nameTooLong() {
-
-			SignupRequest request = new SignupRequest("ok@ok.com", PASSWORD, "긴이름123");
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.registerUser(request));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_MEMBERNAME_FORMAT);
-		}
-
-		@Test
-		@DisplayName("비밀번호 보안 기준 미달이면 예외 발생")
-		void weakPassword() {
-
-			SignupRequest request = new SignupRequest("ok@ok.com", "1234", NAME);
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.registerUser(request));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.WEAK_PASSWORD);
-		}
-	}
-
-	@Nested
-	@DisplayName("로그인(login)")
-	class LoginTest {
-
-		@BeforeEach
-		void setupMember() {
-
-			Member member = Member.ofLocalMember(
-					EMAIL,
-					NAME,
-					passwordEncoder.encode(PASSWORD),
-					OAuthProvider.LOCAL,
-					ROLE);
-			memberRepository.save(member);
-		}
-
-		@Test
-		@DisplayName("정상적으로 로그인된다")
-		void login_success() {
-
-			LoginRequest request = new LoginRequest(EMAIL, PASSWORD);
-			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-			LoginResponse loginResponse = memberService.login(request, response);
-
-			assertThat(loginResponse).isNotNull();
-			assertThat(loginResponse.getName()).isEqualTo(NAME);
-			assertThat(loginResponse.getMessage()).contains("성공");
-		}
-
-		@Test
-		@DisplayName("회원이 없으면 예외 발생")
-		void memberNotFound() {
-
-			LoginRequest request = new LoginRequest("none@aaa.com", PASSWORD);
-			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.login(request, response));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.MEMBER_NOT_FOUND);
-		}
-
-		@Test
-		@DisplayName("비밀번호 불일치 시 예외 발생")
-		void invalidPassword() {
-
-			LoginRequest request = new LoginRequest(EMAIL, "Wrong123");
-			HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.login(request, response));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.INVALID_PASSWORD);
-		}
-	}
-
-	@Nested
-	@DisplayName("findUserByEmailAndProvider")
-	class FindUserByEmailAndProviderTest {
-
-		@Test
-		@DisplayName("정상적으로 찾을 수 있다")
-		void find_success() {
-
-			Member member = Member.ofLocalMember(
-					EMAIL,
-					NAME,
-					passwordEncoder.encode(PASSWORD),
-					OAuthProvider.LOCAL,
-					ROLE);
-			memberRepository.save(member);
-
-			Member found = memberService.findUserByEmailAndProvider(EMAIL, OAuthProvider.LOCAL);
-			assertThat(found).isNotNull();
-			assertThat(found.getEmail()).isEqualTo(EMAIL);
-		}
-
-		@Test
-		@DisplayName("없는 경우 예외")
-		void not_found() {
-
-			GlobalException ex = assertThrows(GlobalException.class,
-					() -> memberService.findUserByEmailAndProvider("none@none.com",
-							OAuthProvider.LOCAL));
-			assertThat(ex.getResultCode()).isEqualTo(ResultCode.MEMBER_NOT_FOUND);
+				// then
+				assertThat(response.getCash()).isEqualTo(CASH_5000);
+			}
 		}
 	}
 }

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -83,7 +83,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
 @ExtendWith(MockitoExtension.class)
 @DisplayName("상품 서비스 테스트")
 class ProductServiceTest {


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 회원이 보유한 캐시 조회 기능 구현

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 기존 `MemberServiceTest`는 Mock 기반이 아닌 실제 빈을 주입받는 방식의 테스트였습니다.
이에 따라 해당 테스트 클래스를 `MemberServiceBeanTest`로 이름을 변경해두었습니다 :)
작성자 분께서는 추후 Mock 기반으로 테스트를 리팩토링하신 후, `MemberServiceTest`로 옮겨주시면 감사하겠습니다! 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #121

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?