### PR TITLE
[DP-142] fix: 상품 상세 조회시 판매자 리뷰 쿼리 수정

### DIFF
--- a/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
@@ -15,7 +15,7 @@ public class MobileDataInfoResponse {
 	private String memberName;
 	private float remainAmount;
 	private int pricePer100MB;
-	private double averageRate;
+	private float averageRate;
 	private int reviewCount;
 	private boolean splitType;
 	private LocalDateTime updatedAt;

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dapanda.product.repository;
 
+import static com.dapanda.member.entity.QMember.member;
 import static com.dapanda.product.entity.QMobileData.mobileData;
 import static com.dapanda.product.entity.QProduct.product;
 import static com.dapanda.product.entity.QProductImage.productImage;
@@ -177,19 +178,14 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.member.name,
 						mobileData.remainAmount,
 						mobileData.pricePer100MB,
-						review.rating.avg().coalesce(DEFAULT_RATING),
-						review.rating.count().intValue(),
+						member.averageRating,
+						member.reviewCount,
 						mobileData.isSplitType,
 						product.updatedAt
 				))
 				.from(product)
 				.join(mobileData).on(product.itemId.eq(mobileData.id))
-				.leftJoin(review).on(review.trade.id.eq(
-						JPAExpressions
-								.select(tradeDetails.trade.id)
-								.from(tradeDetails)
-								.where(tradeDetails.product.id.eq(product.id))
-				))
+				.leftJoin(member).on(product.member.id.eq(member.id))
 				.where(isActiveProduct(),
 						product.itemId.eq(mobileData.id),
 						product.id.eq(productId)

--- a/src/test/java/com/dapanda/TestConstants.java
+++ b/src/test/java/com/dapanda/TestConstants.java
@@ -31,7 +31,7 @@ public final class TestConstants {
 		public static final String COMMENT = "좋아요";
 		public static final float NEW_RATING = 1.0f;
 		public static final String NEW_COMMENT = "별로에요";
-		public static final double AVERAGE_RATE = 3.5;
+		public static final float AVERAGE_RATE = 3.5F;
 		public static final int REVIEW_COUNT = 3;
 	}
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 상품 상세 조회시 판매자 리뷰 쿼리 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 기존에는 여러 테이블을 조인하여 판매자의 리뷰 평점과 리뷰 개수를 계산했으나, 다건 결과를 반환하는 서브쿼리로 인해 오류가 발생했습니다.
이에 따라, 해당 Member 엔티티에 있는 필드들을 불러와 쿼리에서 조인 없이 조회할 수 있도록 로직을 수정하였습니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #137

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?