### PR TITLE
[DP-145] fix: 캐시 내역 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
@@ -88,15 +88,15 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 						trade.id,
 						trade.tradeType,
 						trade.tradingPrice,
-						// description: MOBILE -> dataAmount + "GB", WIFI -> timeAmount + "시간"
 						new CaseBuilder()
 								.when(trade.tradeType.in(TradeType.MOBILE_PURCHASE_SINGLE,
 										TradeType.MOBILE_PURCHASE_COMPOSITE))
-								.then(Expressions.stringTemplate("concat({0}, 'GB')",
-										trade.dataAmount))
+								// SQL 문자열 연결 연산자 이용
+								.then(Expressions.stringTemplate("'' || {0}",
+										trade.dataAmount.coalesce(0F)))
 								.when(trade.tradeType.eq(TradeType.WIFI))
-								.then(Expressions.stringTemplate("concat({0}, '분')",
-										trade.timeAmount))
+								.then(Expressions.stringTemplate("'' || {0}",
+										trade.timeAmount.coalesce(0)))
 								.otherwise("-"),
 						trade.createdAt
 				))

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -1405,7 +1405,7 @@ class TradeControllerTest {
 												"거래 금액"),
 										fieldWithPath(
 												"data.cashHistorySummary.data[].description").description(
-												"거래 설명"),
+												"거래 설명 (데이터: GB, 와이파이: 분, 나머지: '-')"),
 										fieldWithPath(
 												"data.cashHistorySummary.data[].createdAt").description(
 												"거래 생성 시각"),

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -786,11 +786,11 @@ class TradeServiceTest {
 						CursorPageResponse.of(
 								List.of(
 										new CashHistorySummary(TRADE_ID_1, wifiTrade.getTradeType(),
-												wifiTrade.getTradingPrice(), "0.5GB",
+												wifiTrade.getTradingPrice(), "0.5",
 												LocalDateTime.now()),
 										new CashHistorySummary(TRADE_ID_2,
 												chargeTrade.getTradeType(),
-												wifiTrade.getTradingPrice(), "60분",
+												wifiTrade.getTradingPrice(), "60",
 												LocalDateTime.now())
 								),
 								PageInfo.of(null, false, 2)


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 캐시 내역 조회 쿼리 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 기존에는 아래와 같이 단위를 포함한 문자열을 쿼리에서 생성하고 있었습니다.
```java
.then(Expressions.stringTemplate("concat({0}, 'GB')", trade.dataAmount))
.when(trade.tradeType.eq(TradeType.WIFI))
.then(Expressions.stringTemplate("concat({0}, '분')", trade.timeAmount))
```
- 해당 방식에 대해 @hyeonZIP  님께서 주신 피드백을 반영하여, 쿼리에서는 순수 데이터만 반환하도록 수정하였습니다.
의견 주셔서 감사합니다! 😊
```java
.then(Expressions.stringTemplate("'' || {0}", trade.dataAmount.coalesce(0F)))
.when(trade.tradeType.eq(TradeType.WIFI))
.then(Expressions.stringTemplate("'' || {0}", trade.timeAmount.coalesce(0)))
```

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #141

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?