### PR TITLE
[DP-150] feat: 상품 판매 정보 조회에 전체 상품 수 추가

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -703,7 +703,7 @@ include::{snippets}/product/market-price/response-fields.adoc[]
 
 ==== 회원의 판매 상품 목록 조회
 
-`GET /api/members/{memberId}selling-product`
+`GET /api/members/{memberId}/selling-product`
 
 ===== 요청 파라미터
 

--- a/src/main/java/com/dapanda/common/dto/response/CountCursorPageResponse.java
+++ b/src/main/java/com/dapanda/common/dto/response/CountCursorPageResponse.java
@@ -1,0 +1,44 @@
+package com.dapanda.common.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CountCursorPageResponse<T> {
+
+	private List<T> data;
+	private PageInfo pageInfo;
+	private long count;
+
+	public static <T> CountCursorPageResponse<T> of(List<T> data, PageInfo pageInfo, long count) {
+
+		return CountCursorPageResponse.<T>builder()
+				.data(data)
+				.pageInfo(pageInfo)
+				.count(count)
+				.build();
+	}
+
+	@Getter
+	@Builder(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class PageInfo {
+
+		private final Long nextCursorId;
+		private final boolean hasNext;
+		private final int size;
+
+		public static PageInfo of(Long nextCursorId, boolean hasNext, int size) {
+
+			return PageInfo.builder()
+					.nextCursorId(nextCursorId)
+					.hasNext(hasNext)
+					.size(size)
+					.build();
+		}
+	}
+}

--- a/src/main/java/com/dapanda/product/controller/ProductController.java
+++ b/src/main/java/com/dapanda/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.dapanda.product.controller;
 
 import com.dapanda.auth.entity.CustomUserDetails;
+import com.dapanda.common.dto.response.CountCursorPageResponse;
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.common.exception.CommonResponse;
 import com.dapanda.common.exception.GlobalException;
@@ -28,7 +29,7 @@ public class ProductController {
 	private final ProductService productService;
 
 	@GetMapping("/members/{memberId}/selling-products")
-	public CommonResponse<CursorPageResponse<ReadSellingProductResponse>> readSellingProductHistory(
+	public CommonResponse<CountCursorPageResponse<ReadSellingProductResponse>> readSellingProductHistory(
 
 			@PathVariable Long memberId,
 			@RequestParam ProductState productState,
@@ -42,7 +43,7 @@ public class ProductController {
 	}
 
 	@GetMapping("/selling-products")
-	public CommonResponse<CursorPageResponse<ReadSellingProductResponse>> readMySellingProductHistory(
+	public CommonResponse<CountCursorPageResponse<ReadSellingProductResponse>> readMySellingProductHistory(
 			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@RequestParam ProductState productState,
 			@RequestParam(required = false) Long cursorId,

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
@@ -4,15 +4,13 @@ import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
 import com.dapanda.product.dto.request.ReadSellingProductRequest;
-import com.dapanda.product.dto.response.FindMarketPriceResponse;
-import com.dapanda.product.dto.response.MobileDataInfoResponse;
-import com.dapanda.product.dto.response.ReadSellingProductResponse;
-import com.dapanda.product.dto.response.WifiInfoResponse;
+import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.ItemType;
 import com.dapanda.product.entity.ProductSortOption;
 import com.dapanda.trade.dto.MobileDataScrap;
-import java.util.List;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ProductCustomRepository {
@@ -36,4 +34,6 @@ public interface ProductCustomRepository {
 	List<MobileDataScrap> findMobileDataScrap(float dataAmount);
 
 	FindMarketPriceResponse findMarketPrice(ItemType itemType);
+
+	Long countSellingProduct(ReadSellingProductRequest request);
 }

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -1,5 +1,24 @@
 package com.dapanda.product.repository;
 
+import com.dapanda.common.dto.response.CursorPageResponse;
+import com.dapanda.product.dto.MobileDataSummary;
+import com.dapanda.product.dto.WifiSummary;
+import com.dapanda.product.dto.request.ReadSellingProductRequest;
+import com.dapanda.product.dto.response.*;
+import com.dapanda.product.entity.*;
+import com.dapanda.trade.dto.MobileDataScrap;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static com.dapanda.member.entity.QMember.member;
 import static com.dapanda.product.entity.QMobileData.mobileData;
 import static com.dapanda.product.entity.QProduct.product;
@@ -7,32 +26,6 @@ import static com.dapanda.product.entity.QProductImage.productImage;
 import static com.dapanda.product.entity.QWifi.wifi;
 import static com.dapanda.review.entity.QReview.review;
 import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
-
-import com.dapanda.common.dto.response.CursorPageResponse;
-import com.dapanda.product.dto.MobileDataSummary;
-import com.dapanda.product.dto.WifiSummary;
-import com.dapanda.product.dto.request.ReadSellingProductRequest;
-import com.dapanda.product.dto.response.FindMarketPriceResponse;
-import com.dapanda.product.dto.response.MobileDataInfoResponse;
-import com.dapanda.product.dto.response.ReadSellingProductResponse;
-import com.dapanda.product.dto.response.WifiInfoResponse;
-import com.dapanda.product.entity.ItemType;
-import com.dapanda.product.entity.ProductSortOption;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.QProductImage;
-import com.dapanda.trade.dto.MobileDataScrap;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDateTime;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -458,4 +451,23 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 		);
 	}
 
+	public Long countSellingProduct(ReadSellingProductRequest request) {
+
+		return queryFactory
+				.select(product.count())
+				.from(product)
+				.leftJoin(mobileData).on(
+						product.itemId.eq(mobileData.id)
+								.and(product.itemType.eq(ItemType.MOBILE_DATA))
+				)
+				.leftJoin(wifi).on(
+						product.itemId.eq(wifi.id)
+								.and(product.itemType.eq(ItemType.WIFI))
+				)
+				.where(
+						product.member.id.eq(request.memberId()),
+						request.productState() != null ? product.state.eq(request.productState()) : null
+				)
+				.fetchOne();
+	}
 }

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.dapanda.product.service;
 
+import com.dapanda.common.dto.response.CountCursorPageResponse;
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.common.exception.GlobalException;
 import com.dapanda.common.exception.ResultCode;
@@ -7,32 +8,17 @@ import com.dapanda.member.entity.Member;
 import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
-import com.dapanda.product.dto.request.CreateMobileDataRequest;
-import com.dapanda.product.dto.request.CreateWifiRequest;
-import com.dapanda.product.dto.request.ReadSellingProductRequest;
-import com.dapanda.product.dto.request.UpdateMobileDataRequest;
-import com.dapanda.product.dto.request.UpdateWifiRequest;
-import com.dapanda.product.dto.response.FindMarketPriceResponse;
-import com.dapanda.product.dto.response.MobileDataInfoResponse;
-import com.dapanda.product.dto.response.ReadSellingProductResponse;
-import com.dapanda.product.dto.response.UpdateMobileDataResponse;
-import com.dapanda.product.dto.response.UpdateWifiResponse;
-import com.dapanda.product.dto.response.WifiInfoResponse;
-import com.dapanda.product.entity.ItemType;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductSortOption;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
+import com.dapanda.product.dto.request.*;
+import com.dapanda.product.dto.response.*;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -47,12 +33,14 @@ public class ProductService {
 
 	private final MemberRepository memberRepository;
 
-	public CursorPageResponse<ReadSellingProductResponse> readSellingProduct(
+	public CountCursorPageResponse<ReadSellingProductResponse> readSellingProduct(
 			ReadSellingProductRequest request) {
 
 		validateMemberId(request.memberId());
 
 		List<ReadSellingProductResponse> response = productRepository.findSellingProduct(request);
+
+		Long count = productRepository.countSellingProduct(request);
 
 		boolean hasNext = response.size() > request.size();
 
@@ -64,17 +52,14 @@ public class ProductService {
 				? response.get(response.size() - 1).getProductId()
 				: null;
 
-		CursorPageResponse.PageInfo pageInfo = CursorPageResponse.PageInfo.of(
+		CountCursorPageResponse.PageInfo pageInfo = CountCursorPageResponse.PageInfo.of(
 				nextCursorId,
 				hasNext,
 				request.size()
 		);
 
-		return CursorPageResponse.of(response, pageInfo);
+		return CountCursorPageResponse.of(response, pageInfo, count);
 	}
-
-//	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(
-//			MobileDataCursorRequest request) {
 
 	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, Integer size,
 			String productSortOption, Float dataAmount) {

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -1486,7 +1486,8 @@ class ProductControllerTest {
 										fieldWithPath("data.pageInfo.hasNext").description(
 												"다음 페이지 존재 여부"),
 										fieldWithPath("data.pageInfo.nextCursorId").description(
-												"다음 페이지 조회 시 사용할 커서 아이디 (다음 페이지가 없으면 null)")
+												"다음 페이지 조회 시 사용할 커서 아이디 (다음 페이지가 없으면 null)"),
+										fieldWithPath("data.count").description("조회된 전체 갯수")
 								)
 						));
 			}
@@ -1635,7 +1636,8 @@ class ProductControllerTest {
 										fieldWithPath("data.pageInfo.hasNext").description(
 												"다음 페이지 존재 여부"),
 										fieldWithPath("data.pageInfo.nextCursorId").description(
-												"다음 페이지 조회 시 사용할 커서 아이디 (다음 페이지가 없으면 null)")
+												"다음 페이지 조회 시 사용할 커서 아이디 (다음 페이지가 없으면 null)"),
+										fieldWithPath("data.count").description("조회된 전체 갯수")
 								)
 						));
 			}

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.dapanda.common.dto.response.CountCursorPageResponse;
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.common.exception.GlobalException;
 import com.dapanda.common.exception.ResultCode;
@@ -994,7 +995,7 @@ class ProductServiceTest {
 				given(productRepository.findSellingProduct(request)).willReturn(queryResponse);
 
 				//when
-				CursorPageResponse<ReadSellingProductResponse> response = productService.readSellingProduct(
+				CountCursorPageResponse<ReadSellingProductResponse> response = productService.readSellingProduct(
 						request);
 
 				//then


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 상품 판매 정보 조회에 전체 상품 수 추가
- 카운트 쿼리 포함된 페이징 응답 DTO 추가

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #150 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?