### PR TITLE
[DP-136] feat: 상품 조회시 판매자 프로필 이미지 및 본인 상품 여부 반환 기능 추가

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -124,7 +124,7 @@ include::{snippets}/member/get-buying-data/http-response.adoc[]
 
 include::{snippets}/member/get-buying-data/response-fields.adoc[]
 
-==== 캐시 조회
+==== 판매 데이터양 조회
 
 `GET` 회원이 판매한 데이터양 조회
 
@@ -142,6 +142,7 @@ include::{snippets}/member/get-selling-data/response-fields.adoc[]
 
 ---
 
+[[resources-chat]]
 === 채팅
 
 ==== WebSocket 프로토콜
@@ -196,7 +197,9 @@ include::{snippets}/chat/chat-room-already-exist/http-response.adoc[]
 
 include::{snippets}/chat/chat-room-already-exist/response-fields.adoc[]
 
-[[resources-payment]]
+---
+
+[[resources-report]]
 === 신고
 
 ==== 신고 생성
@@ -671,11 +674,11 @@ include::{snippets}/product/post-wifi-success/response-fields.adoc[]
 include::{snippets}/product/post-wifi-missing-field-error/http-request.adoc[]
 include::{snippets}/product/post-wifi-missing-field-error/http-response.adoc[]
 
-=== 파일 업로드 Presigned URL 발급
+===== 파일 업로드 Presigned URL 발급
 
 S3 Presigned URL을 발급받아 클라이언트가 직접 S3로 파일을 업로드할 수 있도록 합니다.
 
-==== Presigned URL 단건/복수 발급
+====== Presigned URL 단건/복수 발급
 
 `POST /api/images/presign`
 

--- a/src/main/java/com/dapanda/member/entity/Member.java
+++ b/src/main/java/com/dapanda/member/entity/Member.java
@@ -2,20 +2,8 @@ package com.dapanda.member.entity;
 
 import com.dapanda.auth.entity.OAuthProvider;
 import com.dapanda.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
@@ -61,6 +49,8 @@ public class Member extends BaseEntity {
 	private int reviewCount;
 
 	private float averageRating;
+
+	private String profileImageUrl;
 
 	public static Member ofOAuthMember(String email, String name,
 			OAuthProvider provider, MemberRole role) {
@@ -113,6 +103,7 @@ public class Member extends BaseEntity {
 	}
 
 	public void updateReviewInfo(int reviewCount, float averageRating) {
+
 		this.reviewCount = reviewCount;
 		this.averageRating = averageRating;
 	}

--- a/src/main/java/com/dapanda/product/controller/ProductController.java
+++ b/src/main/java/com/dapanda/product/controller/ProductController.java
@@ -6,17 +6,8 @@ import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.common.exception.CommonResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
-import com.dapanda.product.dto.request.CreateMobileDataRequest;
-import com.dapanda.product.dto.request.CreateWifiRequest;
-import com.dapanda.product.dto.request.ReadSellingProductRequest;
-import com.dapanda.product.dto.request.UpdateMobileDataRequest;
-import com.dapanda.product.dto.request.UpdateWifiRequest;
-import com.dapanda.product.dto.response.FindMarketPriceResponse;
-import com.dapanda.product.dto.response.MobileDataInfoResponse;
-import com.dapanda.product.dto.response.ReadSellingProductResponse;
-import com.dapanda.product.dto.response.UpdateMobileDataResponse;
-import com.dapanda.product.dto.response.UpdateWifiResponse;
-import com.dapanda.product.dto.response.WifiInfoResponse;
+import com.dapanda.product.dto.request.*;
+import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.ProductState;
 import com.dapanda.product.service.ProductService;
 import jakarta.validation.Valid;
@@ -25,15 +16,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -99,16 +82,19 @@ public class ProductController {
 
 	@GetMapping("/products/mobile-data/{productId}")
 	public CommonResponse<MobileDataInfoResponse> getMobileDataInfo(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@PathVariable("productId") Long productId) {
 
-		return CommonResponse.success(productService.findMobileDataInfo(productId));
+		return CommonResponse.success(
+				productService.findMobileDataInfo(productId, userDetails.getId()));
 	}
 
 	@GetMapping("/products/wifi/{productId}")
 	public CommonResponse<WifiInfoResponse> getWifiInfo(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@PathVariable("productId") Long productId) {
 
-		return CommonResponse.success(productService.findWifiInfo(productId));
+		return CommonResponse.success(productService.findWifiInfo(productId, userDetails.getId()));
 	}
 
 	@PostMapping("/products/mobile-data")

--- a/src/main/java/com/dapanda/product/dto/MobileDataSummary.java
+++ b/src/main/java/com/dapanda/product/dto/MobileDataSummary.java
@@ -13,10 +13,11 @@ public class MobileDataSummary extends ProductSummary {
 	private boolean splitType;
 	private LocalDateTime updatedAt;
 
-	public MobileDataSummary(Long id, int price, Long itemId, String memberName, float remainAmount,
+	public MobileDataSummary(Long id, int price, Long itemId, String memberName,
+			String profileImageUrl, float remainAmount,
 			int pricePer100MB, boolean splitType, LocalDateTime updatedAt) {
 
-		super(id, price, itemId, memberName);
+		super(id, price, itemId, memberName, profileImageUrl);
 		this.remainAmount = remainAmount;
 		this.pricePer100MB = pricePer100MB;
 		this.splitType = splitType;

--- a/src/main/java/com/dapanda/product/dto/ProductSummary.java
+++ b/src/main/java/com/dapanda/product/dto/ProductSummary.java
@@ -1,8 +1,6 @@
 package com.dapanda.product.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
@@ -13,4 +11,5 @@ public class ProductSummary {
 	private int price;
 	private Long itemId;
 	private String memberName;
+	private String profileImageUrl;
 }

--- a/src/main/java/com/dapanda/product/dto/WifiSummary.java
+++ b/src/main/java/com/dapanda/product/dto/WifiSummary.java
@@ -18,11 +18,12 @@ public class WifiSummary extends ProductSummary {
 	private boolean open;
 	private LocalDateTime updatedAt;
 
-	public WifiSummary(Long id, int price, Long itemId, String memberName, String title,
+	public WifiSummary(Long id, int price, Long itemId, String memberName, String profileImageUrl,
+			String title,
 			String imageUrl, double latitude, double longitude, String address, double averageRate,
 			double distanceKm, boolean open, LocalDateTime updatedAt) {
 
-		super(id, price, itemId, memberName);
+		super(id, price, itemId, memberName, profileImageUrl);
 		this.title = title;
 		this.imageUrl = imageUrl;
 		this.latitude = latitude;

--- a/src/main/java/com/dapanda/product/dto/WifiSummary.java
+++ b/src/main/java/com/dapanda/product/dto/WifiSummary.java
@@ -13,15 +13,14 @@ public class WifiSummary extends ProductSummary {
 	private double longitude;
 	private String address;
 	private String imageUrl;
-	private double averageRate;
+	private float averageRate;
 	private double distanceKm;
 	private boolean open;
 	private LocalDateTime updatedAt;
 
 	public WifiSummary(Long id, int price, Long itemId, String memberName, String profileImageUrl,
-			String title,
-			String imageUrl, double latitude, double longitude, String address, double averageRate,
-			double distanceKm, boolean open, LocalDateTime updatedAt) {
+			String title, String imageUrl, double latitude, double longitude, String address,
+			float averageRate, double distanceKm, boolean open, LocalDateTime updatedAt) {
 
 		super(id, price, itemId, memberName, profileImageUrl);
 		this.title = title;

--- a/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
@@ -13,6 +13,7 @@ public class MobileDataInfoResponse {
 	private int price;
 	private Long memberId;
 	private String memberName;
+	private String profileImageUrl;
 	private float remainAmount;
 	private int pricePer100MB;
 	private float averageRate;

--- a/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
@@ -18,6 +18,7 @@ public class MobileDataInfoResponse {
 	private int pricePer100MB;
 	private float averageRate;
 	private int reviewCount;
+	private boolean myProduct;
 	private boolean splitType;
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/dapanda/product/dto/response/WifiInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/WifiInfoResponse.java
@@ -21,8 +21,9 @@ public class WifiInfoResponse {
 	private double latitude;
 	private double longitude;
 	private String address;
-	private double averageRate;
+	private float averageRate;
 	private int reviewCount;
+	private boolean myProduct;
 	private List<String> imageUrls;
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;

--- a/src/main/java/com/dapanda/product/dto/response/WifiInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/WifiInfoResponse.java
@@ -2,11 +2,7 @@ package com.dapanda.product.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE, toBuilder = true)
@@ -19,6 +15,7 @@ public class WifiInfoResponse {
 	private int price;
 	private Long memberId;
 	private String memberName;
+	private String profileImageUrl;
 	private String title;
 	private String content;
 	private double latitude;

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
@@ -8,9 +8,8 @@ import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.ItemType;
 import com.dapanda.product.entity.ProductSortOption;
 import com.dapanda.trade.dto.MobileDataScrap;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductCustomRepository {
@@ -21,9 +20,9 @@ public interface ProductCustomRepository {
 	public CursorPageResponse<WifiSummary> findWifiByCursor(Long cursorId, int size,
 			ProductSortOption productSortOption, boolean isOpen, Double latitude, Double longitude);
 
-	public MobileDataInfoResponse findMobileDataInfo(Long productId);
+	public MobileDataInfoResponse findMobileDataInfo(Long productId, Long memberId);
 
-	public WifiInfoResponse findWifiInfo(Long productId);
+	public WifiInfoResponse findWifiInfo(Long productId, Long memberId);
 
 	public List<String> findWifiImages(Long wifiId);
 

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
@@ -30,7 +30,7 @@ public interface ProductCustomRepository {
 
 	List<ReadSellingProductResponse> findSellingProduct(ReadSellingProductRequest request);
 
-	List<MobileDataScrap> findMobileDataScrap(float dataAmount);
+	List<MobileDataScrap> findMobileDataScrap(float dataAmount, Long memberId);
 
 	FindMarketPriceResponse findMarketPrice(ItemType itemType);
 

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -314,7 +314,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	}
 
 	@Override
-	public List<MobileDataScrap> findMobileDataScrap(float dataAmount) {
+	public List<MobileDataScrap> findMobileDataScrap(float dataAmount, Long memberId) {
 
 		return queryFactory
 				.select(Projections.constructor(MobileDataScrap.class,
@@ -332,6 +332,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.from(product)
 				.join(mobileData).on(product.itemId.eq(mobileData.id))
 				.where(
+						product.member.id.ne(memberId),
 						product.state.eq(ProductState.ACTIVE),
 						mobileData.remainAmount.gt(0)
 				)
@@ -340,7 +341,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						mobileData.remainAmount.desc(),
 						mobileData.isSplitType.asc()
 				)
-				.limit(200) // 필요에 따라 조절
+				.limit(100) // 필요에 따라 조절
 				.fetch();
 	}
 

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -1,5 +1,12 @@
 package com.dapanda.product.repository;
 
+import static com.dapanda.member.entity.QMember.member;
+import static com.dapanda.product.entity.QMobileData.mobileData;
+import static com.dapanda.product.entity.QProduct.product;
+import static com.dapanda.product.entity.QProductImage.productImage;
+import static com.dapanda.product.entity.QWifi.wifi;
+import static com.dapanda.review.entity.QReview.review;
+
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
@@ -13,19 +20,10 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static com.dapanda.member.entity.QMember.member;
-import static com.dapanda.product.entity.QMobileData.mobileData;
-import static com.dapanda.product.entity.QProduct.product;
-import static com.dapanda.product.entity.QProductImage.productImage;
-import static com.dapanda.product.entity.QWifi.wifi;
-import static com.dapanda.review.entity.QReview.review;
-import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -52,6 +50,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.price,
 						product.itemId,
 						product.member.name,
+						product.member.profileImageUrl.coalesce(""),
 						mobileData.remainAmount,
 						mobileData.pricePer100MB,
 						mobileData.isSplitType,
@@ -105,12 +104,13 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.price,
 						product.itemId,
 						product.member.name,
+						product.member.profileImageUrl.coalesce(""),
 						wifi.title,
 						Expressions.stringTemplate("MIN({0})", productImage.imageUrl),
 						wifi.latitude,
 						wifi.longitude,
 						wifi.address,
-						review.rating.avg().coalesce(DEFAULT_RATING),
+						member.averageRating,
 						distance.divide(METER_TO_KILOMETER),
 						Expressions.booleanTemplate(
 								"CURRENT_TIMESTAMP BETWEEN {0} AND {1}", wifi.startTime,
@@ -121,12 +121,6 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.from(product)
 				.groupBy(product.id)
 				.join(wifi).on(wifi.id.eq(product.itemId))
-				.leftJoin(review).on(review.trade.id.eq(
-						JPAExpressions
-								.select(tradeDetails.trade.id)
-								.from(tradeDetails)
-								.where(tradeDetails.product.id.eq(product.id))
-				))
 				.where(
 						gtCursorId(cursorId),
 						isOpenNow(isOpen, now)
@@ -174,6 +168,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.price,
 						product.member.id,
 						product.member.name,
+						product.member.profileImageUrl.coalesce(""),
 						mobileData.remainAmount,
 						mobileData.pricePer100MB,
 						member.averageRating,
@@ -184,7 +179,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.from(product)
 				.join(mobileData).on(product.itemId.eq(mobileData.id))
 				.leftJoin(member).on(product.member.id.eq(member.id))
-				.where(isActiveProduct(),
+				.where(isActiveOrSoldOutProduct(),
 						product.itemId.eq(mobileData.id),
 						product.id.eq(productId)
 				)
@@ -203,13 +198,14 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.price,
 						product.member.id,
 						product.member.name,
+						product.member.profileImageUrl.coalesce(""),
 						wifi.title,
 						wifi.content,
 						wifi.latitude,
 						wifi.longitude,
 						wifi.address,
-						review.rating.avg().coalesce(DEFAULT_RATING),
-						review.rating.count().intValue(),
+						member.averageRating,
+						member.reviewCount,
 						Expressions.nullExpression(List.class),
 						wifi.startTime,
 						wifi.endTime,
@@ -221,13 +217,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				))
 				.from(product)
 				.join(wifi).on(product.itemId.eq(wifi.id))
-				.leftJoin(review).on(review.trade.id.eq(
-						JPAExpressions
-								.select(tradeDetails.trade.id)
-								.from(tradeDetails)
-								.where(tradeDetails.product.id.eq(product.id))
-				))
-				.where(isActiveProduct(),
+				.leftJoin(member).on(product.member.id.eq(member.id))
+				.where(isActiveOrSoldOutProduct(),
 						product.itemId.eq(wifi.id),
 						product.id.eq(productId)
 				)
@@ -371,6 +362,11 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 		return product.state.eq(ProductState.ACTIVE);
 	}
 
+	private BooleanExpression isActiveOrSoldOutProduct() {
+
+		return product.state.in(ProductState.ACTIVE, ProductState.SOLD_OUT);
+	}
+
 	private BooleanExpression gtCursorId(Long cursorId) {
 
 		return cursorId != null ? product.id.gt(cursorId) : null;
@@ -466,7 +462,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				)
 				.where(
 						product.member.id.eq(request.memberId()),
-						request.productState() != null ? product.state.eq(request.productState()) : null
+						request.productState() != null ? product.state.eq(request.productState())
+								: null
 				)
 				.fetchOne();
 	}

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -121,6 +121,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.from(product)
 				.groupBy(product.id)
 				.join(wifi).on(wifi.id.eq(product.itemId))
+				.leftJoin(member).on(product.member.id.eq(member.id))
 				.where(
 						gtCursorId(cursorId),
 						isOpenNow(isOpen, now)
@@ -159,7 +160,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	}
 
 	@Override
-	public MobileDataInfoResponse findMobileDataInfo(Long productId) {
+	public MobileDataInfoResponse findMobileDataInfo(Long productId, Long memberId) {
 
 		return queryFactory
 				.select(Projections.constructor(MobileDataInfoResponse.class,
@@ -173,6 +174,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						mobileData.pricePer100MB,
 						member.averageRating,
 						member.reviewCount,
+						Expressions.booleanTemplate("{0} = {1}", product.member.id, memberId),
 						mobileData.isSplitType,
 						product.updatedAt
 				))
@@ -189,7 +191,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	}
 
 	@Override
-	public WifiInfoResponse findWifiInfo(Long productId) {
+	public WifiInfoResponse findWifiInfo(Long productId, Long memberId) {
 
 		return queryFactory
 				.select(Projections.constructor(WifiInfoResponse.class,
@@ -206,6 +208,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						wifi.address,
 						member.averageRating,
 						member.reviewCount,
+						Expressions.booleanTemplate("{0} = {1}", product.member.id, memberId),
 						Expressions.nullExpression(List.class),
 						wifi.startTime,
 						wifi.endTime,

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -76,13 +76,13 @@ public class ProductService {
 				ProductSortOption.from(productSortOption), open, latitude, longitude);
 	}
 
-	public MobileDataInfoResponse findMobileDataInfo(Long productId) {
+	public MobileDataInfoResponse findMobileDataInfo(Long productId, Long memberId) {
 
 		if (!productRepository.existsById(productId)) {
 			throw new GlobalException(ResultCode.PRODUCT_NOT_FOUND);
 		}
 
-		MobileDataInfoResponse response = productRepository.findMobileDataInfo(productId);
+		MobileDataInfoResponse response = productRepository.findMobileDataInfo(productId, memberId);
 
 		if (response == null) {
 			throw new GlobalException(ResultCode.INVALID_PRODUCT);
@@ -91,13 +91,13 @@ public class ProductService {
 		return response;
 	}
 
-	public WifiInfoResponse findWifiInfo(Long productId) {
+	public WifiInfoResponse findWifiInfo(Long productId, Long memberId) {
 
 		if (!productRepository.existsById(productId)) {
 			throw new GlobalException(ResultCode.PRODUCT_NOT_FOUND);
 		}
 
-		WifiInfoResponse response = productRepository.findWifiInfo(productId);
+		WifiInfoResponse response = productRepository.findWifiInfo(productId, memberId);
 
 		if (response == null) {
 			throw new GlobalException(ResultCode.INVALID_PRODUCT);

--- a/src/main/java/com/dapanda/trade/controller/TradeController.java
+++ b/src/main/java/com/dapanda/trade/controller/TradeController.java
@@ -2,25 +2,15 @@ package com.dapanda.trade.controller;
 
 import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.common.exception.CommonResponse;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
-import com.dapanda.trade.dto.response.TradeProductResponse;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
 import com.dapanda.trade.service.TradeService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -40,9 +30,11 @@ public class TradeController {
 
 	@GetMapping("/trades/mobile-data/scrap")
 	public CommonResponse<FindMobileDataScrapResponse> defaultPurchaseMobileData(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@RequestParam Float dataAmount) {
 
-		return CommonResponse.success(tradeService.findMobileDataScrap(dataAmount));
+		return CommonResponse.success(
+				tradeService.findMobileDataScrap(dataAmount, userDetails.getId()));
 	}
 
 	@PostMapping("/trades/mobile-data/scrap")

--- a/src/main/java/com/dapanda/trade/service/TradeService.java
+++ b/src/main/java/com/dapanda/trade/service/TradeService.java
@@ -7,36 +7,17 @@ import com.dapanda.member.entity.Member;
 import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
-import com.dapanda.trade.dto.CashHistoryMonthlySummary;
-import com.dapanda.trade.dto.CashHistorySummary;
-import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.PurchaseHistorySummary;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
-import com.dapanda.trade.dto.response.TradeProductResponse;
-import com.dapanda.trade.entity.Trade;
-import com.dapanda.trade.entity.TradeDetails;
-import com.dapanda.trade.entity.TradeType;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
+import com.dapanda.trade.dto.*;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
+import com.dapanda.trade.entity.*;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
 import jakarta.transaction.Transactional;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -191,10 +172,11 @@ public class TradeService {
 		sellerPlan.deductMobileData(dataAmount);
 	}
 
-	public FindMobileDataScrapResponse findMobileDataScrap(Float dataAmount) {
+	public FindMobileDataScrapResponse findMobileDataScrap(Float dataAmount, Long memberId) {
 
 		// 1. 정렬된 상품 목록 조회 (단가 낮은순, 용량 많은순, 일반우선)
-		List<MobileDataScrap> sortedList = productRepository.findMobileDataScrap(dataAmount);
+		List<MobileDataScrap> sortedList = productRepository.findMobileDataScrap(dataAmount,
+				memberId);
 
 		// 2. 가능한 조합들을 저장할 리스트
 		List<List<MobileDataScrap>> candidates = new ArrayList<>(); // 가능한 조합들을 저장하는 리스트

--- a/src/test/java/com/dapanda/TestConstants.java
+++ b/src/test/java/com/dapanda/TestConstants.java
@@ -17,6 +17,7 @@ public final class TestConstants {
 		public static final int CASH_5000 = 5000;
 		public static final float BUYING_DATA = 1F;
 		public static final float SELLING_DATA = 1F;
+		public static final String PROFILE_IMAGE_URL = "imageUrl.jpg";
 	}
 
 	public static final class Pagination {

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -383,12 +383,12 @@ class ProductControllerTest {
 						.andDo(document("product/get-products-mobile-data",
 								queryParameters(
 										parameterWithName("cursorId").description(
-												"마지막 커서 아이디 (필수 X)").optional(),
+												"마지막 커서 아이디 (선택)").optional(),
 										parameterWithName("size").description(
 												"페이지 사이즈 (필수, 1 이상 정수)"),
 										parameterWithName("productSortOption").description(
-												"정렬 조건 (필수 X, 기본값: 최신순) - RECENT(최신순), PRICE_ASC(가격 낮은순), AMOUNT_ASC(데이터 용량 적은순), AMOUNT_DESC(데이터 용량 많은순"),
-										parameterWithName("dataAmount").description("데이터 양 (필수 X)")
+												"정렬 조건 (필수, 기본값: 최신순) - RECENT(최신순), PRICE_ASC(가격 낮은순), AMOUNT_ASC(데이터 용량 적은순), AMOUNT_DESC(데이터 용량 많은순"),
+										parameterWithName("dataAmount").description("데이터 양 (선택)")
 												.optional()
 								),
 								responseFields(
@@ -533,12 +533,12 @@ class ProductControllerTest {
 						.andDo(document("product/get-products-wifi",
 								queryParameters(
 										parameterWithName("cursorId").description(
-												"마지막 커서 아이디 (필수 X)"),
+												"마지막 커서 아이디 (선택)"),
 										parameterWithName("size").description(
 												"페이지 사이즈 (필수, 1 이상 정수)"),
 										parameterWithName("productSortOption").description(
-												"정렬 조건 (필수 X) - PRICE_ASC(가격 낮은순), AVERAGE_RATE_DESC(평점 높은순)"),
-										parameterWithName("open").description("영업중 여부 (필수 X)"),
+												"정렬 조건 (필수) - PRICE_ASC(가격 낮은순), AVERAGE_RATE_DESC(평점 높은순), DISTANCE_ASC(거리 가까운순)"),
+										parameterWithName("open").description("영업중 여부 (선택)"),
 										parameterWithName("latitude").description("사용자의 위도 (필수 O)"),
 										parameterWithName("longitude").description("사용자의 경도 (필수 O)")
 								),

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -512,6 +512,8 @@ class ProductControllerTest {
 				Product product3 = ProductFixture.createWifiProduct(5000, wifi3.getId(), member);
 				productRepository.saveAll(List.of(product1, product2, product3));
 
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
 				// when & then
 				mockMvc.perform(MockMvcRequestBuilders.get("/api/products/wifi")
 								.param("cursorId", String.valueOf(cursorId))
@@ -521,7 +523,9 @@ class ProductControllerTest {
 								.param("latitude", String.valueOf(latitude))
 								.param("longitude", String.valueOf(longitude))
 								.contentType(MediaType.APPLICATION_JSON)
-						)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
@@ -637,13 +641,18 @@ class ProductControllerTest {
 						MobileDataFixture.createMobileData(DATA_AMOUNT_1, REMAIN_AMOUNT_1,
 								PRICE_PER_100MB_300));
 
-				productRepository.save(
+				Product product = productRepository.save(
 						ProductFixture.createMobileDataProduct(PRICE_3000, mobileData.getId(),
 								member));
 
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
 				// when & then
-				mockMvc.perform(get("/api/products/mobile-data/{productId}", PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+				mockMvc.perform(get("/api/products/mobile-data/{productId}", product.getId())
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.data.productId").value(PRODUCT_ID))
 						.andExpect(jsonPath("$.data.itemId").value(mobileData.getId()))
@@ -655,6 +664,7 @@ class ProductControllerTest {
 						.andExpect(jsonPath("$.data.pricePer100MB").value(PRICE_PER_100MB_300))
 						.andExpect(jsonPath("$.data.averageRate").exists())
 						.andExpect(jsonPath("$.data.reviewCount").exists())
+						.andExpect(jsonPath("$.data.myProduct").exists())
 						.andExpect(jsonPath("$.data.splitType").exists())
 						.andExpect(jsonPath("$.data.updatedAt").exists())
 						.andDo(document("product/get-mobile-data-info",
@@ -675,13 +685,14 @@ class ProductControllerTest {
 												"100MB 당 가격"),
 										fieldWithPath("data.averageRate").description("평균 별점"),
 										fieldWithPath("data.reviewCount").description("리뷰 수"),
+										fieldWithPath("data.myProduct").description("자신이 등록한 글 여부"),
 										fieldWithPath("data.splitType").description("분할 여부"),
 										fieldWithPath("data.updatedAt").description("수정된 시간")
 								))
 						);
 
 				MobileDataInfoResponse actualResponse = productService.findMobileDataInfo(
-						PRODUCT_ID);
+						PRODUCT_ID, member.getId());
 
 				assertThat(actualResponse.getProductId()).isEqualTo(PRODUCT_ID);
 				assertThat(actualResponse.getItemId()).isEqualTo(mobileData.getId());
@@ -698,9 +709,17 @@ class ProductControllerTest {
 			@DisplayName("데이터 상품 상세 조회 시 상품 아이디가 존재하지 않으면 예외를 던진다")
 			void throwsExceptionWhenProductIdNotExist() throws Exception {
 
-				// given & when & then
+				// given
+				Member member = memberRepository.save(MemberFixture.createMember1());
+
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
+				// when & then
 				mockMvc.perform(get("/api/products/mobile-data/{productId}", INVALID_PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isBadRequest())
 						.andDo(document("product/get-mobile-data-info-not-exist-product-id-error",
 								responseFields(
@@ -721,14 +740,19 @@ class ProductControllerTest {
 						MobileDataFixture.createMobileData(DATA_AMOUNT_1, REMAIN_AMOUNT_1,
 								PRICE_PER_100MB_300));
 
-				productRepository.save(
+				Product product = productRepository.save(
 						ProductFixture.createMobileDataProductInactive(PRICE_3000,
 								mobileData.getId(),
 								member));
 
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
 				// when & then
-				mockMvc.perform(get("/api/products/mobile-data/{productId}", PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+				mockMvc.perform(get("/api/products/mobile-data/{productId}", product.getId() + 1)
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isBadRequest())
 						.andDo(document("product/get-mobile-data-info-invalid-product-error",
 								responseFields(
@@ -767,9 +791,14 @@ class ProductControllerTest {
 				productImageRepository.save(
 						ProductImageFixture.createProductImage(IMAGE_URL_2, 2, wifi.getId()));
 
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
 				// when & then
 				mockMvc.perform(get("/api/products/wifi/{productId}", PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.data.productId").value(PRODUCT_ID))
 						.andExpect(jsonPath("$.data.itemId").value(wifi.getId()))
@@ -785,6 +814,7 @@ class ProductControllerTest {
 						.andExpect(jsonPath("$.data.content").value(CONTENT))
 						.andExpect(jsonPath("$.data.averageRate").exists())
 						.andExpect(jsonPath("$.data.reviewCount").exists())
+						.andExpect(jsonPath("$.data.myProduct").exists())
 						.andExpect(jsonPath("$.data.imageUrls").exists())
 						.andExpect(jsonPath("$.data.startTime").exists())
 						.andExpect(jsonPath("$.data.endTime").exists())
@@ -810,6 +840,7 @@ class ProductControllerTest {
 										fieldWithPath("data.address").description("주소"),
 										fieldWithPath("data.averageRate").description("평균 별점"),
 										fieldWithPath("data.reviewCount").description("리뷰 수"),
+										fieldWithPath("data.myProduct").description("자신이 등록한 글 여부"),
 										fieldWithPath("data.imageUrls[]").description(
 												"이미지 URL (우선순위 높은순)"),
 										fieldWithPath("data.startTime").description("시작 시간"),
@@ -819,7 +850,8 @@ class ProductControllerTest {
 								))
 						);
 
-				WifiInfoResponse actualResponse = productService.findWifiInfo(PRODUCT_ID);
+				WifiInfoResponse actualResponse = productService.findWifiInfo(PRODUCT_ID,
+						member.getId());
 
 				assertThat(actualResponse.getProductId()).isEqualTo(PRODUCT_ID);
 				assertThat(actualResponse.getItemId()).isEqualTo(wifi.getId());
@@ -834,9 +866,17 @@ class ProductControllerTest {
 			@DisplayName("와이파이 상품 상세 조회 시 상품 아이디가 존재하지 않으면 예외를 던진다")
 			void throwsExceptionWhenProductIdNotExist() throws Exception {
 
-				// given & when & then
+				// given
+				Member member = memberRepository.save(MemberFixture.createMember1());
+
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
+				// when & then
 				mockMvc.perform(get("/api/products/wifi/{productId}", INVALID_PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isBadRequest())
 						.andDo(document("product/get-wifi-info-not-exist-product-id-error",
 								responseFields(
@@ -847,7 +887,7 @@ class ProductControllerTest {
 			}
 
 			@Test
-			@DisplayName("데이터 상품 상세 조회 시 상품이 유효하지 않으면 예외를 던진다")
+			@DisplayName("와이파이 상품 상세 조회 시 상품이 유효하지 않으면 예외를 던진다")
 			void throwsExceptionWhenProductInvalid() throws Exception {
 
 				// given
@@ -857,12 +897,17 @@ class ProductControllerTest {
 						WifiFixture.createWifi(TITLE, CONTENT, LATITUDE, LONGITUDE,
 								ADDRESS, START_TIME, END_TIME));
 
-				productRepository.save(
+				Product product = productRepository.save(
 						ProductFixture.createWifiProductInactive(PRICE_3000, wifi.getId(), member));
 
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+
 				// when & then
-				mockMvc.perform(get("/api/products/wifi/{productId}", PRODUCT_ID)
-								.contentType(MediaType.APPLICATION_JSON))
+				mockMvc.perform(get("/api/products/wifi/{productId}", product.getId() + 1)
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isBadRequest())
 						.andDo(document("product/get-wifi-info-invalid-product-error",
 								responseFields(
@@ -895,8 +940,7 @@ class ProductControllerTest {
 						ProductFixture.createMobileDataProduct(PRICE_3000, mobileData.getId(),
 								member));
 
-				CustomUserDetails userDetails = mock(CustomUserDetails.class);
-				given(userDetails.getId()).willReturn(member.getId());
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
 
 				UpdateMobileDataRequest request = new UpdateMobileDataRequest(product.getId(),
 						NEW_PRICE_9000, CHANGED_AMOUNT, SPLIT_TYPE);

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -403,9 +403,9 @@ class ProductControllerTest {
 										fieldWithPath("data.data[].itemId").description(
 												"모바일 데이터 아이디"),
 										fieldWithPath("data.data[].memberName").description(
-												"등록한 회원 이름"),
+												"상품을 등록한 회원 이름"),
 										fieldWithPath("data.data[].profileImageUrl").description(
-												"등록한 회원의 프로필 이미지 URL"),
+												"상품을 등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.data[].remainAmount").description(
 												"데이터 잔여량"),
 										fieldWithPath("data.data[].pricePer100MB").description(
@@ -554,9 +554,9 @@ class ProductControllerTest {
 										fieldWithPath("data.data[].itemId").description(
 												"와이파이 아이디"),
 										fieldWithPath("data.data[].memberName").description(
-												"등록한 회원 이름"),
+												"상품을 등록한 회원 이름"),
 										fieldWithPath("data.data[].profileImageUrl").description(
-												"등록한 회원의 프로필 이미지 URL"),
+												"상품을 등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.data[].title").description("게시물 제목"),
 										fieldWithPath("data.data[].imageUrl").description(
 												"대표 이미지 URL").optional(),
@@ -679,7 +679,7 @@ class ProductControllerTest {
 										fieldWithPath("data.memberName").description(
 												"상품을 등록한 회원의 이름"),
 										fieldWithPath("data.profileImageUrl").description(
-												"등록한 회원의 프로필 이미지 URL"),
+												"상품을 등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.remainAmount").description("남은 데이터양"),
 										fieldWithPath("data.pricePer100MB").description(
 												"100MB 당 가격"),
@@ -832,7 +832,7 @@ class ProductControllerTest {
 										fieldWithPath("data.memberName").description(
 												"상품을 등록한 회원의 이름"),
 										fieldWithPath("data.profileImageUrl").description(
-												"등록한 회원의 프로필 이미지 URL"),
+												"상품을 등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.title").description("게시물 제목"),
 										fieldWithPath("data.content").description("게시물 내용"),
 										fieldWithPath("data.latitude").description("위도"),

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -50,31 +50,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static com.dapanda.TestConstants.Member.USER_DETAILS_MEMBER_ID;
-import static com.dapanda.TestConstants.MobileData.*;
-import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
-import static com.dapanda.TestConstants.Product.*;
-import static com.dapanda.TestConstants.Wifi.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest
 @Import(TestConfig.class)
 @ActiveProfiles("test")
@@ -429,6 +404,8 @@ class ProductControllerTest {
 												"모바일 데이터 아이디"),
 										fieldWithPath("data.data[].memberName").description(
 												"등록한 회원 이름"),
+										fieldWithPath("data.data[].profileImageUrl").description(
+												"등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.data[].remainAmount").description(
 												"데이터 잔여량"),
 										fieldWithPath("data.data[].pricePer100MB").description(
@@ -574,6 +551,8 @@ class ProductControllerTest {
 												"와이파이 아이디"),
 										fieldWithPath("data.data[].memberName").description(
 												"등록한 회원 이름"),
+										fieldWithPath("data.data[].profileImageUrl").description(
+												"등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.data[].title").description("게시물 제목"),
 										fieldWithPath("data.data[].imageUrl").description(
 												"대표 이미지 URL").optional(),
@@ -671,6 +650,7 @@ class ProductControllerTest {
 						.andExpect(jsonPath("$.data.price").value(PRICE_3000))
 						.andExpect(jsonPath("$.data.memberId").value(member.getId()))
 						.andExpect(jsonPath("$.data.memberName").value(member.getName()))
+						.andExpect(jsonPath("$.data.profileImageUrl").value(""))
 						.andExpect(jsonPath("$.data.remainAmount").value(REMAIN_AMOUNT_1))
 						.andExpect(jsonPath("$.data.pricePer100MB").value(PRICE_PER_100MB_300))
 						.andExpect(jsonPath("$.data.averageRate").exists())
@@ -688,6 +668,8 @@ class ProductControllerTest {
 												"상품을 등록한 회원의 아이디"),
 										fieldWithPath("data.memberName").description(
 												"상품을 등록한 회원의 이름"),
+										fieldWithPath("data.profileImageUrl").description(
+												"등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.remainAmount").description("남은 데이터양"),
 										fieldWithPath("data.pricePer100MB").description(
 												"100MB 당 가격"),
@@ -794,6 +776,7 @@ class ProductControllerTest {
 						.andExpect(jsonPath("$.data.price").value(PRICE_3000))
 						.andExpect(jsonPath("$.data.memberId").value(member.getId()))
 						.andExpect(jsonPath("$.data.memberName").value(member.getName()))
+						.andExpect(jsonPath("$.data.profileImageUrl").value(""))
 						.andExpect(jsonPath("$.data.title").value(TITLE))
 						.andExpect(jsonPath("$.data.content").value(CONTENT))
 						.andExpect(jsonPath("$.data.latitude").value(LATITUDE))
@@ -818,6 +801,8 @@ class ProductControllerTest {
 												"상품을 등록한 회원의 아이디"),
 										fieldWithPath("data.memberName").description(
 												"상품을 등록한 회원의 이름"),
+										fieldWithPath("data.profileImageUrl").description(
+												"등록한 회원의 프로필 이미지 URL"),
 										fieldWithPath("data.title").description("게시물 제목"),
 										fieldWithPath("data.content").description("게시물 내용"),
 										fieldWithPath("data.latitude").description("위도"),

--- a/src/test/java/com/dapanda/product/entity/MobileDataFixture.java
+++ b/src/test/java/com/dapanda/product/entity/MobileDataFixture.java
@@ -86,6 +86,7 @@ public class MobileDataFixture {
 				price,
 				itemId,
 				memberName,
+				"profile.jpg",
 				remainAmount,
 				pricePer100MB,
 				isSplitType,

--- a/src/test/java/com/dapanda/product/entity/WifiFixture.java
+++ b/src/test/java/com/dapanda/product/entity/WifiFixture.java
@@ -28,6 +28,7 @@ public class WifiFixture {
 				price,
 				itemId,
 				memberName,
+				"image.jpg",
 				title,
 				"imageUrl",
 				latitude,

--- a/src/test/java/com/dapanda/product/entity/WifiFixture.java
+++ b/src/test/java/com/dapanda/product/entity/WifiFixture.java
@@ -20,7 +20,7 @@ public class WifiFixture {
 	}
 
 	public static WifiSummary createWifiSummary(Long id, int price, Long itemId, String memberName,
-			String title, double latitude, double longitude, String address, double averageRate,
+			String title, double latitude, double longitude, String address, float averageRate,
 			double distanceKm, boolean isOpen, LocalDateTime updatedAt) {
 
 		return new WifiSummary(

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -1,8 +1,8 @@
 package com.dapanda.product.service;
 
 import static com.dapanda.TestConstants.Member.*;
-import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.MobileData.*;
+import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_CURSOR_ID;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Product.*;
@@ -296,10 +296,10 @@ class ProductServiceTest {
 
 				// given
 				List<MobileDataSummary> summaries = new ArrayList<>();
-				summaries.add(new MobileDataSummary(1L, 1000, 1L, "회원1", 5.0F, 200,
+				summaries.add(new MobileDataSummary(1L, 1000, 1L, "회원1", "profile.jpg", 5.0F, 200,
 						false, UPDATED_AT));
 				summaries.add(
-						new MobileDataSummary(2L, 2000, 2L, "회원2", 10, 200,
+						new MobileDataSummary(2L, 2000, 2L, "회원2", "profile.jpg", 10, 200,
 								false, UPDATED_AT));
 				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(2L, false, 2));
@@ -450,10 +450,12 @@ class ProductServiceTest {
 				// given
 				List<WifiSummary> summaries = new ArrayList<>();
 				summaries.add(
-						new WifiSummary(1L, 1000, 1L, "회원1", "상품제목1", "imageUrl", 37.0, 127.0,
+						new WifiSummary(1L, 1000, 1L, "회원1", "image.jpg",
+								"상품제목1", "imageUrl", 37.0, 127.0,
 								ADDRESS, 5, 5, true, UPDATED_AT));
 				summaries.add(
-						new WifiSummary(2L, 2000, 2L, "회원2", "상품제목2", "imageUrl", 37.1, 127.1,
+						new WifiSummary(2L, 2000, 2L, "회원2", "image.jpg",
+								"상품제목2", "imageUrl", 37.1, 127.1,
 								ADDRESS, 10, 10, true, UPDATED_AT));
 				CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(2L, false, 2));
@@ -510,7 +512,8 @@ class ProductServiceTest {
 						REMAIN_AMOUNT_1, PRICE_PER_100MB_300);
 				MobileDataInfoResponse expectedResponse = new MobileDataInfoResponse(PRODUCT_ID,
 						mobileData.getId(), PRICE_3000, member.getId(), member.getName(),
-						REMAIN_AMOUNT_1, PRICE_PER_100MB_300, AVERAGE_RATE, REVIEW_COUNT, false,
+						PROFILE_IMAGE_URL, REMAIN_AMOUNT_1, PRICE_PER_100MB_300, AVERAGE_RATE,
+						REVIEW_COUNT, false,
 						UPDATED_AT);
 
 				given(productRepository.existsById(PRODUCT_ID))
@@ -579,8 +582,9 @@ class ProductServiceTest {
 				Wifi wifi = WifiFixture.createWifi(TITLE, CONTENT, LATITUDE, LONGITUDE,
 						ADDRESS, START_TIME, END_TIME);
 				WifiInfoResponse expectedResponse = new WifiInfoResponse(PRODUCT_ID,
-						wifi.getId(), PRICE_3000, member.getId(), member.getName(), TITLE, CONTENT,
-						LATITUDE, LONGITUDE, ADDRESS, AVERAGE_RATE, REVIEW_COUNT, null, START_TIME,
+						wifi.getId(), PRICE_3000, member.getId(), member.getName(),
+						PROFILE_IMAGE_URL, TITLE, CONTENT, LATITUDE, LONGITUDE, ADDRESS,
+						AVERAGE_RATE, REVIEW_COUNT, null, START_TIME,
 						END_TIME, true, UPDATED_AT);
 
 				given(productRepository.existsById(PRODUCT_ID))

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -425,7 +425,7 @@ class ProductServiceTest {
 					summaries.add(
 							WifiFixture.createWifiSummary((long) i, 1000, (long) i,
 									"회원" + i, "상품제목" + idx, 37.0 + idx, 127.0 + idx, ADDRESS,
-									3F, idx, true, UPDATED_AT));
+									1F + i, idx, true, UPDATED_AT));
 				}
 				CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(3L, false, 3));
@@ -440,7 +440,7 @@ class ProductServiceTest {
 
 				// then
 				assertThat(result.getData()).hasSize(3);
-				assertThat(result.getData().get(0).getAverageRate()).isEqualTo(4.0);
+				assertThat(result.getData().get(0).getAverageRate()).isEqualTo(4.0F);
 			}
 
 			@Test

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -354,7 +354,7 @@ class ProductServiceTest {
 				for (int i = 1; i <= 3; i++) {
 					summaries.add(
 							WifiFixture.createWifiSummary((long) i, 100 + i, (long) i,
-									"회원" + i, "상품제목" + i, 37.0 + i, 127.0 + i, ADDRESS, i * 10.0, i,
+									"회원" + i, "상품제목" + i, 37.0 + i, 127.0 + i, ADDRESS, 3F, i,
 									true, UPDATED_AT));
 				}
 				CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
@@ -389,7 +389,7 @@ class ProductServiceTest {
 							37.0 + i,
 							127.0 + i,
 							ADDRESS,
-							i * 10.0,
+							3F,
 							i % 2 == 0 ? 2 : 1,
 							true,
 							UPDATED_AT
@@ -425,7 +425,7 @@ class ProductServiceTest {
 					summaries.add(
 							WifiFixture.createWifiSummary((long) i, 1000, (long) i,
 									"회원" + i, "상품제목" + idx, 37.0 + idx, 127.0 + idx, ADDRESS,
-									5.0 - idx, idx, true, UPDATED_AT));
+									3F, idx, true, UPDATED_AT));
 				}
 				CursorPageResponse<WifiSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(3L, false, 3));
@@ -513,17 +513,16 @@ class ProductServiceTest {
 				MobileDataInfoResponse expectedResponse = new MobileDataInfoResponse(PRODUCT_ID,
 						mobileData.getId(), PRICE_3000, member.getId(), member.getName(),
 						PROFILE_IMAGE_URL, REMAIN_AMOUNT_1, PRICE_PER_100MB_300, AVERAGE_RATE,
-						REVIEW_COUNT, false,
-						UPDATED_AT);
+						REVIEW_COUNT, true, false, UPDATED_AT);
 
 				given(productRepository.existsById(PRODUCT_ID))
 						.willReturn(true);
-				given(productRepository.findMobileDataInfo(PRODUCT_ID)).willReturn(
+				given(productRepository.findMobileDataInfo(PRODUCT_ID, MEMBER_ID)).willReturn(
 						expectedResponse);
 
 				// when
 				MobileDataInfoResponse actualResponse = productService.findMobileDataInfo(
-						PRODUCT_ID);
+						PRODUCT_ID, MEMBER_ID);
 
 				// then
 				assertThat(actualResponse.getItemId()).isEqualTo(mobileData.getId());
@@ -543,7 +542,8 @@ class ProductServiceTest {
 					given(productRepository.existsById(PRODUCT_ID)).willReturn(false);
 
 					// when & then
-					assertThatThrownBy(() -> productService.findMobileDataInfo(PRODUCT_ID))
+					assertThatThrownBy(
+							() -> productService.findMobileDataInfo(PRODUCT_ID, MEMBER_ID))
 							.isInstanceOf(GlobalException.class)
 							.hasMessage(ResultCode.PRODUCT_NOT_FOUND.getMessage());
 				}
@@ -554,10 +554,12 @@ class ProductServiceTest {
 
 					// given
 					given(productRepository.existsById(PRODUCT_ID)).willReturn(true);
-					given(productRepository.findMobileDataInfo(PRODUCT_ID)).willReturn(null);
+					given(productRepository.findMobileDataInfo(PRODUCT_ID, MEMBER_ID)).willReturn(
+							null);
 
 					// when & then
-					assertThatThrownBy(() -> productService.findMobileDataInfo(PRODUCT_ID))
+					assertThatThrownBy(
+							() -> productService.findMobileDataInfo(PRODUCT_ID, MEMBER_ID))
 							.isInstanceOf(GlobalException.class)
 							.hasMessage(ResultCode.INVALID_PRODUCT.getMessage());
 				}
@@ -584,16 +586,17 @@ class ProductServiceTest {
 				WifiInfoResponse expectedResponse = new WifiInfoResponse(PRODUCT_ID,
 						wifi.getId(), PRICE_3000, member.getId(), member.getName(),
 						PROFILE_IMAGE_URL, TITLE, CONTENT, LATITUDE, LONGITUDE, ADDRESS,
-						AVERAGE_RATE, REVIEW_COUNT, null, START_TIME,
+						AVERAGE_RATE, REVIEW_COUNT, false, null, START_TIME,
 						END_TIME, true, UPDATED_AT);
 
 				given(productRepository.existsById(PRODUCT_ID))
 						.willReturn(true);
-				given(productRepository.findWifiInfo(PRODUCT_ID)).willReturn(
+				given(productRepository.findWifiInfo(PRODUCT_ID, MEMBER_ID)).willReturn(
 						expectedResponse);
 
 				// when
-				WifiInfoResponse actualResponse = productService.findWifiInfo(PRODUCT_ID);
+				WifiInfoResponse actualResponse = productService.findWifiInfo(PRODUCT_ID,
+						MEMBER_ID);
 
 				// then
 				assertThat(actualResponse.getItemId()).isEqualTo(wifi.getId());
@@ -614,7 +617,7 @@ class ProductServiceTest {
 				given(productRepository.existsById(PRODUCT_ID)).willReturn(false);
 
 				// when & then
-				assertThatThrownBy(() -> productService.findWifiInfo(PRODUCT_ID))
+				assertThatThrownBy(() -> productService.findWifiInfo(PRODUCT_ID, MEMBER_ID))
 						.isInstanceOf(GlobalException.class)
 						.hasMessage(ResultCode.PRODUCT_NOT_FOUND.getMessage());
 			}
@@ -625,10 +628,10 @@ class ProductServiceTest {
 
 				// given
 				given(productRepository.existsById(PRODUCT_ID)).willReturn(true);
-				given(productRepository.findWifiInfo(PRODUCT_ID)).willReturn(null);
+				given(productRepository.findWifiInfo(PRODUCT_ID, MEMBER_ID)).willReturn(null);
 
 				// when & then
-				assertThatThrownBy(() -> productService.findWifiInfo(PRODUCT_ID))
+				assertThatThrownBy(() -> productService.findWifiInfo(PRODUCT_ID, MEMBER_ID))
 						.isInstanceOf(GlobalException.class)
 						.hasMessage(ResultCode.INVALID_PRODUCT.getMessage());
 			}

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -170,7 +170,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
@@ -242,7 +242,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
@@ -315,7 +315,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
@@ -363,7 +363,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
@@ -414,7 +414,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
@@ -470,7 +470,7 @@ class TradeControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("mobileDataId").description("데이터 아이디 (필수)"),
 										fieldWithPath("dataAmount").description(
-												"구매할 데이터양 (필수 X, 분할 구매는 필수)")
+												"구매할 데이터양 (선택, 분할 구매는 필수)")
 								),
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -2,32 +2,17 @@ package com.dapanda.trade.controller;
 
 
 import static com.dapanda.TestConstants.Member.CASH_5000;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_2;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_150;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_300;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_2;
+import static com.dapanda.TestConstants.MobileData.*;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Plan.PROVIDING_DATA_AMOUNT_10;
-import static com.dapanda.TestConstants.Product.PRICE_1500;
-import static com.dapanda.TestConstants.Product.PRICE_3000;
-import static com.dapanda.TestConstants.Product.PRICE_500;
-import static com.dapanda.TestConstants.Wifi.ADDRESS;
-import static com.dapanda.TestConstants.Wifi.CONTENT;
-import static com.dapanda.TestConstants.Wifi.END_TIME;
-import static com.dapanda.TestConstants.Wifi.LATITUDE;
-import static com.dapanda.TestConstants.Wifi.LONGITUDE;
-import static com.dapanda.TestConstants.Wifi.START_TIME;
-import static com.dapanda.TestConstants.Wifi.TITLE;
+import static com.dapanda.TestConstants.Product.*;
+import static com.dapanda.TestConstants.Wifi.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -45,25 +30,12 @@ import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.entity.PlanFixture;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.ItemType;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.MobileDataFixture;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductFixture;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.entity.WifiFixture;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
 import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
+import com.dapanda.trade.dto.request.*;
 import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.entity.Trade;
-import com.dapanda.trade.entity.TradeDetails;
-import com.dapanda.trade.entity.TradeFixture;
+import com.dapanda.trade.entity.*;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
 import com.dapanda.trade.service.TradeService;
@@ -71,13 +43,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import java.util.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -529,7 +496,8 @@ class TradeControllerTest {
 				// given
 				Member seller1 = MemberFixture.createMember1();
 				Member seller2 = MemberFixture.createMember2();
-				List<Member> members = Arrays.asList(seller1, seller2);
+				Member buyer = MemberFixture.createMember3();
+				List<Member> members = Arrays.asList(seller1, seller2, buyer);
 				memberRepository.saveAll(members);
 
 				MobileData mobileData1 = MobileDataFixture.createMobileData(DATA_AMOUNT_1,
@@ -548,11 +516,15 @@ class TradeControllerTest {
 
 				float dataAmount = DATA_AMOUNT_2;
 
+				CustomUserDetails userDetails = CustomUserDetails.from(buyer);
+
 				// when & then
 				mockMvc.perform(get("/api/trades/mobile-data/scrap")
 								.param("dataAmount", String.valueOf(dataAmount))
 								.contentType(MediaType.APPLICATION_JSON)
-						)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
@@ -598,7 +570,7 @@ class TradeControllerTest {
 						);
 
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
-						dataAmount);
+						dataAmount, buyer.getId());
 
 				assertThat(response.getTotalAmount()).isEqualTo(DATA_AMOUNT_2);
 				assertThat(response.getTotalPrice()).isEqualTo(
@@ -628,13 +600,19 @@ class TradeControllerTest {
 			void findDataProductScrapWhenNotExist() throws Exception {
 
 				// given
+				Member buyer = memberRepository.save(MemberFixture.createMember1());
+
 				float dataAmount = DATA_AMOUNT_2;
+
+				CustomUserDetails userDetails = CustomUserDetails.from(buyer);
 
 				// when & then
 				mockMvc.perform(get("/api/trades/mobile-data/scrap")
 								.param("dataAmount", String.valueOf(dataAmount))
 								.contentType(MediaType.APPLICATION_JSON)
-						)
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
@@ -655,7 +633,7 @@ class TradeControllerTest {
 						);
 
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
-						dataAmount);
+						dataAmount, buyer.getId());
 
 				assertThat(response.getTotalAmount()).isEqualTo(0);
 				assertThat(response.getTotalPrice()).isEqualTo(0); // 조합된 상품의 총 가격

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -1,34 +1,14 @@
 package com.dapanda.trade.service;
 
-import static com.dapanda.TestConstants.Member.BUYER_MEMBER_ID;
-import static com.dapanda.TestConstants.Member.CASH_3000;
-import static com.dapanda.TestConstants.Member.CASH_5000;
-import static com.dapanda.TestConstants.Member.MEMBER_ID;
-import static com.dapanda.TestConstants.Member.SELLER_MEMBER_ID;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_2;
-import static com.dapanda.TestConstants.MobileData.MOBILE_DATA_ID;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_150;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_300;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_2;
+import static com.dapanda.TestConstants.Member.*;
+import static com.dapanda.TestConstants.MobileData.*;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_CURSOR_ID;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Plan.PROVIDING_DATA_AMOUNT_10;
-import static com.dapanda.TestConstants.Product.PRICE_1500;
-import static com.dapanda.TestConstants.Product.PRICE_3000;
-import static com.dapanda.TestConstants.Product.PRICE_500;
-import static com.dapanda.TestConstants.Product.PRODUCT_ID;
+import static com.dapanda.TestConstants.Product.*;
 import static com.dapanda.TestConstants.Trade.TRADE_ID_1;
 import static com.dapanda.TestConstants.Trade.TRADE_ID_2;
-import static com.dapanda.TestConstants.Wifi.ADDRESS;
-import static com.dapanda.TestConstants.Wifi.CONTENT;
-import static com.dapanda.TestConstants.Wifi.END_TIME;
-import static com.dapanda.TestConstants.Wifi.LATITUDE;
-import static com.dapanda.TestConstants.Wifi.LONGITUDE;
-import static com.dapanda.TestConstants.Wifi.START_TIME;
-import static com.dapanda.TestConstants.Wifi.TITLE;
-import static com.dapanda.TestConstants.Wifi.WIFI_ID;
+import static com.dapanda.TestConstants.Wifi.*;
 import static com.dapanda.trade.entity.TradeType.WIFI;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -44,39 +24,19 @@ import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.entity.PlanFixture;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.MobileDataFixture;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductFixture;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.entity.WifiFixture;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
-import com.dapanda.trade.dto.CashHistoryMonthlySummary;
-import com.dapanda.trade.dto.CashHistorySummary;
-import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.PurchaseHistorySummary;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
+import com.dapanda.trade.dto.*;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
 import com.dapanda.trade.entity.Trade;
 import com.dapanda.trade.entity.TradeFixture;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import java.util.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -364,12 +324,13 @@ class TradeServiceTest {
 
 				float dataAmount = DATA_AMOUNT_2;
 
-				given(productRepository.findMobileDataScrap(dataAmount)).willReturn(new ArrayList<>(
+				given(productRepository.findMobileDataScrap(dataAmount,
+						BUYER_MEMBER_ID)).willReturn(new ArrayList<>(
 						List.of(mobileDataScrap1, mobileDataScrap2)));
 
 				// when
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
-						dataAmount);
+						dataAmount, BUYER_MEMBER_ID);
 
 				// then
 				assertThat(response.getTotalAmount()).isEqualTo(DATA_AMOUNT_2);
@@ -405,12 +366,13 @@ class TradeServiceTest {
 
 				float dataAmount = DATA_AMOUNT_2;
 
-				given(productRepository.findMobileDataScrap(dataAmount)).willReturn(
+				given(productRepository.findMobileDataScrap(dataAmount,
+						BUYER_MEMBER_ID)).willReturn(
 						new ArrayList<>());
 
 				// when
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
-						dataAmount);
+						dataAmount, BUYER_MEMBER_ID);
 
 				// then
 				assertThat(response.getTotalAmount()).isEqualTo(0);


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 상품 조회 전반적인 기능 추가
  - 상품 목록 조회시 평균 별점, 리뷰 개수 쿼리 수정
  - 상품 조회시 판매자의 프로필 이미지도 같이 반환하도록 추가
  - 상품 상세 조회시 상품 상태가 비활성화여도 조회가 가능하도록 수정, 자신이 등록한 상품 여부 같이 반환하도록 추가
  - 데이터 상품 분할 구매시 자신의 상품 안보이도록 수정
  - API 명세서 일부 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- Member Entity에 profileImageUrl 필드가 추가됐습니다. 관련 작업 하실 때 참고해주세요!

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #129

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?