### PR TITLE
[DP-163] fix: 데이터 단위 float에서 BigDecimal로 수정

### DIFF
--- a/src/main/java/com/dapanda/member/dto/response/FindDataResponse.java
+++ b/src/main/java/com/dapanda/member/dto/response/FindDataResponse.java
@@ -1,11 +1,8 @@
 package com.dapanda.member.dto.response;
 
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import lombok.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -13,9 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindDataResponse {
 
-	private float data;
+	private BigDecimal data;
 
-	public static FindDataResponse of(float data) {
+	public static FindDataResponse of(BigDecimal data) {
 
 		return FindDataResponse.builder()
 				.data(data)

--- a/src/main/java/com/dapanda/member/entity/Member.java
+++ b/src/main/java/com/dapanda/member/entity/Member.java
@@ -2,20 +2,9 @@ package com.dapanda.member.entity;
 
 import com.dapanda.auth.entity.OAuthProvider;
 import com.dapanda.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import lombok.*;
 
 @Entity
 @Getter
@@ -44,9 +33,9 @@ public class Member extends BaseEntity {
 	@Column(nullable = false)
 	private OAuthProvider provider;
 
-	private float buyingData;
+	private BigDecimal buyingData;
 
-	private float sellingData;
+	private BigDecimal sellingData;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -102,14 +91,14 @@ public class Member extends BaseEntity {
 	}
 
 	// TODO: 매달 1일 초기화 메서드
-	public void addBuyingData(float buyingData) {
+	public void addBuyingData(BigDecimal buyingData) {
 
-		this.buyingData += buyingData;
+		this.buyingData = this.buyingData.add(buyingData);
 	}
 
-	public void addSellingData(float sellingData) {
+	public void addSellingData(BigDecimal sellingData) {
 
-		this.sellingData += sellingData;
+		this.sellingData = this.sellingData.add(sellingData);
 	}
 
 	public void updateReviewInfo(int reviewCount, float averageRating) {

--- a/src/main/java/com/dapanda/member/service/MemberService.java
+++ b/src/main/java/com/dapanda/member/service/MemberService.java
@@ -17,6 +17,7 @@ import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.refreshToken.service.RefreshTokenService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -130,14 +131,14 @@ public class MemberService {
 
 	public FindDataResponse findBuyingData(Long memberId) {
 
-		float buyingData = memberRepository.findById(memberId).orElseThrow().getBuyingData();
+		BigDecimal buyingData = memberRepository.findById(memberId).orElseThrow().getBuyingData();
 
 		return FindDataResponse.of(buyingData);
 	}
 
 	public FindDataResponse findSellingData(Long memberId) {
 
-		float sellingData = memberRepository.findById(memberId).orElseThrow().getSellingData();
+		BigDecimal sellingData = memberRepository.findById(memberId).orElseThrow().getSellingData();
 
 		return FindDataResponse.of(sellingData);
 	}

--- a/src/main/java/com/dapanda/plan/dto/response/PlanInfoResponse.java
+++ b/src/main/java/com/dapanda/plan/dto/response/PlanInfoResponse.java
@@ -1,11 +1,8 @@
 package com.dapanda.plan.dto.response;
 
 import com.dapanda.plan.entity.Plan;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import lombok.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -14,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class PlanInfoResponse {
 
 	private String name;
-	private float providingDataAmount;
+	private BigDecimal providingDataAmount;
 	private int monthlyPrice;
 
 	public static PlanInfoResponse of(Plan plan) {

--- a/src/main/java/com/dapanda/plan/entity/Plan.java
+++ b/src/main/java/com/dapanda/plan/entity/Plan.java
@@ -2,20 +2,9 @@ package com.dapanda.plan.entity;
 
 import com.dapanda.common.entity.BaseEntity;
 import com.dapanda.member.entity.Member;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -32,7 +21,7 @@ public class Plan extends BaseEntity {
 
 	private String name;
 
-	private float providingDataAmount;
+	private BigDecimal providingDataAmount;
 
 	private int monthlyPrice;
 
@@ -47,7 +36,7 @@ public class Plan extends BaseEntity {
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Member member;
 
-	public static Plan of(String name, float providingDataAmount, int monthlyPrice,
+	public static Plan of(String name, BigDecimal providingDataAmount, int monthlyPrice,
 			PlanCategory category, AgeGroup ageGroup, Member member) {
 
 		return Plan.builder()
@@ -60,13 +49,13 @@ public class Plan extends BaseEntity {
 				.build();
 	}
 
-	public void addMobileData(float dataAmount) {
+	public void addMobileData(BigDecimal dataAmount) {
 
-		this.providingDataAmount += dataAmount;
+		this.providingDataAmount = this.providingDataAmount.add(dataAmount);
 	}
 
-	public void deductMobileData(float dataAmount) {
+	public void deductMobileData(BigDecimal dataAmount) {
 
-		this.providingDataAmount -= dataAmount;
+		this.providingDataAmount.subtract(dataAmount);
 	}
 }

--- a/src/main/java/com/dapanda/plan/entity/Plan.java
+++ b/src/main/java/com/dapanda/plan/entity/Plan.java
@@ -56,6 +56,6 @@ public class Plan extends BaseEntity {
 
 	public void deductMobileData(BigDecimal dataAmount) {
 
-		this.providingDataAmount.subtract(dataAmount);
+		this.providingDataAmount = this.providingDataAmount.subtract(dataAmount);
 	}
 }

--- a/src/main/java/com/dapanda/plan/service/PlanService.java
+++ b/src/main/java/com/dapanda/plan/service/PlanService.java
@@ -4,10 +4,9 @@ import com.dapanda.common.exception.GlobalException;
 import com.dapanda.common.exception.ResultCode;
 import com.dapanda.member.entity.Member;
 import com.dapanda.plan.dto.response.PlanInfoResponse;
-import com.dapanda.plan.entity.AgeGroup;
-import com.dapanda.plan.entity.Plan;
-import com.dapanda.plan.entity.PlanCategory;
+import com.dapanda.plan.entity.*;
 import com.dapanda.plan.repository.PlanRepository;
+import java.math.BigDecimal;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,7 +33,7 @@ public class PlanService {
 		PlanCategory category = randomCategory();
 		AgeGroup ageGroup = randomAgeGroup();
 		String name = randomPlanName(category, ageGroup);
-		float dataAmount = randomDataAmount();
+		BigDecimal dataAmount = new BigDecimal(randomDataAmount());
 		int price = randomMonthlyPrice();
 
 		Plan plan = Plan.of(

--- a/src/main/java/com/dapanda/product/controller/ProductController.java
+++ b/src/main/java/com/dapanda/product/controller/ProductController.java
@@ -6,34 +6,18 @@ import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.common.exception.CommonResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
-import com.dapanda.product.dto.request.CreateMobileDataRequest;
-import com.dapanda.product.dto.request.CreateWifiRequest;
-import com.dapanda.product.dto.request.ReadSellingProductRequest;
-import com.dapanda.product.dto.request.UpdateMobileDataRequest;
-import com.dapanda.product.dto.request.UpdateWifiRequest;
-import com.dapanda.product.dto.response.FindMarketPriceResponse;
-import com.dapanda.product.dto.response.MobileDataInfoResponse;
-import com.dapanda.product.dto.response.ReadSellingProductResponse;
-import com.dapanda.product.dto.response.UpdateMobileDataResponse;
-import com.dapanda.product.dto.response.UpdateWifiResponse;
-import com.dapanda.product.dto.response.WifiInfoResponse;
+import com.dapanda.product.dto.request.*;
+import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.ProductState;
 import com.dapanda.product.service.ProductService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -76,7 +60,7 @@ public class ProductController {
 			@RequestParam(required = false) Long cursorId,
 			@RequestParam @Min(1) Integer size,
 			@RequestParam String productSortOption,
-			@RequestParam(required = false) Float dataAmount) {
+			@RequestParam(required = false) BigDecimal dataAmount) {
 
 		return CommonResponse.success(
 				productService.findMobileDataByCursor(cursorId, size, productSortOption,

--- a/src/main/java/com/dapanda/product/dto/MobileDataSummary.java
+++ b/src/main/java/com/dapanda/product/dto/MobileDataSummary.java
@@ -1,5 +1,6 @@
 package com.dapanda.product.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,12 +9,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MobileDataSummary extends ProductSummary {
 
-	private float remainAmount;
+	private BigDecimal remainAmount;
 	private int pricePer100MB;
 	private boolean splitType;
 	private LocalDateTime updatedAt;
 
-	public MobileDataSummary(Long id, int price, Long itemId, String memberName, float remainAmount,
+	public MobileDataSummary(Long id, int price, Long itemId, String memberName,
+			BigDecimal remainAmount,
 			int pricePer100MB, boolean splitType, LocalDateTime updatedAt) {
 
 		super(id, price, itemId, memberName);

--- a/src/main/java/com/dapanda/product/dto/ProductSummary.java
+++ b/src/main/java/com/dapanda/product/dto/ProductSummary.java
@@ -1,15 +1,13 @@
 package com.dapanda.product.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductSummary {
 
-	private Long id;
+	private Long productId;
 	private int price;
 	private Long itemId;
 	private String memberName;

--- a/src/main/java/com/dapanda/product/dto/request/CreateMobileDataRequest.java
+++ b/src/main/java/com/dapanda/product/dto/request/CreateMobileDataRequest.java
@@ -1,6 +1,7 @@
 package com.dapanda.product.dto.request;
 
 import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
 import lombok.Getter;
 
 @Getter
@@ -9,14 +10,14 @@ public class CreateMobileDataRequest extends CreateProductRequest {
 	@NotNull(message = "dataAmount는 null일 수 없습니다.")
 	@DecimalMin(value = "0.1", message = "dataAmount는 최소 0.1GB 이상이어야 합니다.")
 	@DecimalMax(value = "2.0", message = "dataAmount는 최대 2.0GB 이하여야 합니다.")
-	private final Float dataAmount; // GB 단위
+	private final BigDecimal dataAmount; // GB 단위
 
 	@NotNull(message = "isSplitType는 null일 수 없습니다.")
 	private final Boolean isSplitType;
 
 	public CreateMobileDataRequest(
 			Integer price,
-			Float dataAmount,
+			BigDecimal dataAmount,
 			Boolean isSplitType
 	) {
 		super(price);

--- a/src/main/java/com/dapanda/product/dto/request/MobileDataCursorRequest.java
+++ b/src/main/java/com/dapanda/product/dto/request/MobileDataCursorRequest.java
@@ -1,14 +1,15 @@
 package com.dapanda.product.dto.request;
 
+import java.math.BigDecimal;
 import lombok.Getter;
 
 @Getter
 public class MobileDataCursorRequest extends ProductCursorRequest {
 
-	private final Float dataAmount;
+	private final BigDecimal dataAmount;
 
 	public MobileDataCursorRequest(Long cursorId, Integer size,
-			String productSortOption, Float dataAmount) {
+			String productSortOption, BigDecimal dataAmount) {
 
 		super(cursorId, size, productSortOption);
 		this.dataAmount = dataAmount;

--- a/src/main/java/com/dapanda/product/dto/request/UpdateMobileDataRequest.java
+++ b/src/main/java/com/dapanda/product/dto/request/UpdateMobileDataRequest.java
@@ -2,6 +2,7 @@ package com.dapanda.product.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 
 public record UpdateMobileDataRequest(
 
@@ -13,7 +14,7 @@ public record UpdateMobileDataRequest(
 		int price,
 
 		@NotNull(message = "변경된 데이터양은 필수입니다.")
-		float changedAmount,
+		BigDecimal changedAmount,
 
 		@NotNull(message = "분할 여부는 필수입니다.")
 		boolean isSplitType) {

--- a/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/MobileDataInfoResponse.java
@@ -1,5 +1,6 @@
 package com.dapanda.product.dto.response;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +14,7 @@ public class MobileDataInfoResponse {
 	private int price;
 	private Long memberId;
 	private String memberName;
-	private float remainAmount;
+	private BigDecimal remainAmount;
 	private int pricePer100MB;
 	private float averageRate;
 	private int reviewCount;

--- a/src/main/java/com/dapanda/product/dto/response/ReadSellingProductResponse.java
+++ b/src/main/java/com/dapanda/product/dto/response/ReadSellingProductResponse.java
@@ -3,9 +3,9 @@ package com.dapanda.product.dto.response;
 import com.dapanda.product.entity.ItemType;
 import com.dapanda.product.entity.ProductState;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
-
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -19,9 +19,9 @@ public class ReadSellingProductResponse {
 
 	// Mobile Data
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	private Float dataAmount;
+	private BigDecimal dataAmount;
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	private Float remainAmount;
+	private BigDecimal remainAmount;
 
 	// WIFI
 	@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,8 +36,8 @@ public class ReadSellingProductResponse {
 			Long productId,
 			ItemType type,
 			ProductState state,
-			Float dataAmount,
-			Float remainAmount,
+			BigDecimal dataAmount,
+			BigDecimal remainAmount,
 			LocalDateTime createdAt,
 			LocalDateTime updatedAt) {
 

--- a/src/main/java/com/dapanda/product/entity/MobileData.java
+++ b/src/main/java/com/dapanda/product/entity/MobileData.java
@@ -1,6 +1,7 @@
 package com.dapanda.product.entity;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import lombok.*;
 
 @Entity
@@ -15,12 +16,12 @@ public class MobileData {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	private float dataAmount;
-	private float remainAmount;
+	private BigDecimal dataAmount;
+	private BigDecimal remainAmount;
 	private int pricePer100MB;
 	private boolean isSplitType;
 
-	public static MobileData of(float dataAmount, float remainAmount, int pricePer100MB,
+	public static MobileData of(BigDecimal dataAmount, BigDecimal remainAmount, int pricePer100MB,
 			boolean isSplitType) {
 
 		return MobileData.builder()
@@ -31,10 +32,12 @@ public class MobileData {
 				.build();
 	}
 
-	public static MobileData singleOf(float dataAmount, int totalPrice, boolean isSplitType) {
+	public static MobileData singleOf(BigDecimal dataAmount, int totalPrice, boolean isSplitType) {
 
-		int pricePer100MB = (int) Math.ceil(totalPrice / (dataAmount * 10));
-
+		int pricePer100MB = new BigDecimal(totalPrice)
+				.divide(dataAmount.multiply(BigDecimal.TEN), 0, java.math.RoundingMode.CEILING)
+				.intValue();
+		
 		return MobileData.builder()
 				.dataAmount(dataAmount)
 				.remainAmount(dataAmount)
@@ -43,16 +46,16 @@ public class MobileData {
 				.build();
 	}
 
-	public void updateMobileData(float changedAmount, int pricePer100MB, boolean isSplitType) {
+	public void updateMobileData(BigDecimal changedAmount, int pricePer100MB, boolean isSplitType) {
 
-		this.dataAmount += changedAmount;
-		this.remainAmount += changedAmount;
+		this.dataAmount = this.dataAmount.add(changedAmount);
+		this.remainAmount = this.remainAmount.add(changedAmount);
 		this.pricePer100MB = pricePer100MB;
 		this.isSplitType = isSplitType;
 	}
 
-	public void deductRemainAmount(float dataAmount) {
+	public void deductRemainAmount(BigDecimal dataAmount) {
 
-		this.remainAmount -= dataAmount;
+		this.remainAmount = this.remainAmount.subtract(dataAmount);
 	}
 }

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
@@ -8,15 +8,15 @@ import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.ItemType;
 import com.dapanda.product.entity.ProductSortOption;
 import com.dapanda.trade.dto.MobileDataScrap;
-import org.springframework.stereotype.Repository;
-
+import java.math.BigDecimal;
 import java.util.List;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductCustomRepository {
 
 	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, int size,
-			ProductSortOption productSortOption, Float dataAmount);
+			ProductSortOption productSortOption, BigDecimal dataAmount);
 
 	public CursorPageResponse<WifiSummary> findWifiByCursor(Long cursorId, int size,
 			ProductSortOption productSortOption, boolean isOpen, Double latitude, Double longitude);
@@ -27,11 +27,11 @@ public interface ProductCustomRepository {
 
 	public List<String> findWifiImages(Long wifiId);
 
-	public Float sumSoldMobileDataAmountByMemberId(Long memberId);
+	public BigDecimal sumSoldMobileDataAmountByMemberId(Long memberId);
 
 	List<ReadSellingProductResponse> findSellingProduct(ReadSellingProductRequest request);
 
-	List<MobileDataScrap> findMobileDataScrap(float dataAmount);
+	List<MobileDataScrap> findMobileDataScrap(BigDecimal dataAmount);
 
 	FindMarketPriceResponse findMarketPrice(ItemType itemType);
 

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -1,5 +1,13 @@
 package com.dapanda.product.repository;
 
+import static com.dapanda.member.entity.QMember.member;
+import static com.dapanda.product.entity.QMobileData.mobileData;
+import static com.dapanda.product.entity.QProduct.product;
+import static com.dapanda.product.entity.QProductImage.productImage;
+import static com.dapanda.product.entity.QWifi.wifi;
+import static com.dapanda.review.entity.QReview.review;
+import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
+
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.dto.MobileDataSummary;
 import com.dapanda.product.dto.WifiSummary;
@@ -13,19 +21,11 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static com.dapanda.member.entity.QMember.member;
-import static com.dapanda.product.entity.QMobileData.mobileData;
-import static com.dapanda.product.entity.QProduct.product;
-import static com.dapanda.product.entity.QProductImage.productImage;
-import static com.dapanda.product.entity.QWifi.wifi;
-import static com.dapanda.review.entity.QReview.review;
-import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -44,7 +44,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
 	@Override
 	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, int size,
-			ProductSortOption productSortOption, Float dataAmount) {
+			ProductSortOption productSortOption, BigDecimal dataAmount) {
 
 		List<MobileDataSummary> content = queryFactory
 				.select(Projections.constructor(MobileDataSummary.class,
@@ -320,7 +320,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	}
 
 	@Override
-	public List<MobileDataScrap> findMobileDataScrap(float dataAmount) {
+	public List<MobileDataScrap> findMobileDataScrap(BigDecimal dataAmount) {
 
 		return queryFactory
 				.select(Projections.constructor(MobileDataScrap.class,
@@ -351,9 +351,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	}
 
 	@Override
-	public Float sumSoldMobileDataAmountByMemberId(Long memberId) {
+	public BigDecimal sumSoldMobileDataAmountByMemberId(Long memberId) {
 
-		Float sum = queryFactory
+		BigDecimal sum = queryFactory
 				.select(mobileData.dataAmount.sum())
 				.from(product)
 				.join(mobileData).on(product.itemId.eq(mobileData.id))
@@ -363,7 +363,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				)
 				.fetchOne();
 
-		return sum != null ? sum : 0f;
+		return sum != null ? sum : new BigDecimal("0");
 	}
 
 	private BooleanExpression isActiveProduct() {
@@ -376,9 +376,11 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 		return cursorId != null ? product.id.gt(cursorId) : null;
 	}
 
-	private BooleanExpression eqDataAmount(Float dataAmount) {
+	private BooleanExpression eqDataAmount(BigDecimal dataAmount) {
 
-		return dataAmount != null ? mobileData.remainAmount.eq(dataAmount) : null;
+		return dataAmount != null
+				? Expressions.booleanTemplate("ABS({0} - {1}) < 0.000001", mobileData.remainAmount,
+				dataAmount) : null;
 	}
 
 	private BooleanExpression isOpenNow(boolean isOpen, LocalDateTime now) {
@@ -466,7 +468,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				)
 				.where(
 						product.member.id.eq(request.memberId()),
-						request.productState() != null ? product.state.eq(request.productState()) : null
+						request.productState() != null ? product.state.eq(request.productState())
+								: null
 				)
 				.fetchOne();
 	}

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -80,7 +80,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 		if (hasNext) {
 			content.remove(size);
 		}
-		Long nextCursorId = hasNext ? content.get(content.size() - 1).getId() : null;
+		Long nextCursorId = hasNext ? content.get(content.size() - 1).getProductId() : null;
 
 		return CursorPageResponse.of(content,
 				CursorPageResponse.PageInfo.of(nextCursorId, hasNext, content.size()));
@@ -158,7 +158,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 		if (hasNext) {
 			content.remove(size);
 		}
-		Long nextCursorId = hasNext ? content.get(content.size() - 1).getId() : null;
+		Long nextCursorId = hasNext ? content.get(content.size() - 1).getProductId() : null;
 
 		return CursorPageResponse.of(content,
 				CursorPageResponse.PageInfo.of(nextCursorId, hasNext, content.size()));
@@ -330,7 +330,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.price,
 						Expressions.constant(0),
 						mobileData.remainAmount,
-						Expressions.constant(0f),
+						Expressions.constant(BigDecimal.valueOf(0)),
 						mobileData.pricePer100MB,
 						mobileData.isSplitType,
 						product.updatedAt

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -13,6 +13,7 @@ import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.*;
 import com.dapanda.product.repository.*;
 import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +64,7 @@ public class ProductService {
 	}
 
 	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, Integer size,
-			String productSortOption, Float dataAmount) {
+			String productSortOption, BigDecimal dataAmount) {
 
 		return productRepository.findMobileDataByCursor(cursorId, size,
 				ProductSortOption.from(productSortOption), dataAmount);
@@ -114,13 +115,14 @@ public class ProductService {
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new GlobalException(ResultCode.MEMBER_NOT_FOUND));
 
-		Float soldAmount = productRepository.sumSoldMobileDataAmountByMemberId(member.getId());
+		BigDecimal soldAmount = productRepository.sumSoldMobileDataAmountByMemberId(member.getId());
 		if (soldAmount == null) {
-			soldAmount = 0f;
+			soldAmount = BigDecimal.ZERO;
 		}
 
-		float willSellAmount = request.getDataAmount();
-		if (soldAmount + willSellAmount > MobileData.MAX_TRANSFERABLE_DATA_AMOUNT) {
+		BigDecimal willSellAmount = request.getDataAmount();
+		if (soldAmount.add(willSellAmount)
+				.compareTo(BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.EXCEEDED_TRANSFER_LIMIT);
 		}
 
@@ -207,8 +209,8 @@ public class ProductService {
 		validateProductOwner(savedProduct, memberId);
 		validateDataAmount(request.changedAmount(), savedMobileData, memberId);
 
-		int changedPricePer100MB = (int) (request.price() / (savedMobileData.getDataAmount()
-				* 1000));
+		int changedPricePer100MB = (int) Math.ceil(
+				request.price() / (savedMobileData.getDataAmount().floatValue() * 10));
 
 		savedProduct.updatePrice(request.price());
 		savedMobileData.updateMobileData(request.changedAmount(), changedPricePer100MB,
@@ -264,19 +266,21 @@ public class ProductService {
 		}
 	}
 
-	private void validateDataAmount(float changedDataAmount, MobileData savedMobileData,
+	private void validateDataAmount(BigDecimal changedDataAmount, MobileData savedMobileData,
 			Long memberId) {
 
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new GlobalException(ResultCode.MEMBER_NOT_FOUND));
 
-		float resultDataAmount = savedMobileData.getDataAmount() + changedDataAmount;
+		BigDecimal resultDataAmount = savedMobileData.getDataAmount().add(changedDataAmount);
 
-		if (resultDataAmount <= 0 || resultDataAmount > MobileData.MAX_TRANSFERABLE_DATA_AMOUNT) {
+		if (resultDataAmount.compareTo(BigDecimal.ZERO) <= 0 || resultDataAmount.compareTo(
+				BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.INVALID_DATA_TRANSFER_AMOUNT);
 		}
 
-		if (member.getSellingData() + changedDataAmount > MobileData.MAX_TRANSFERABLE_DATA_AMOUNT) {
+		if (member.getSellingData().add(changedDataAmount)
+				.compareTo(BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.EXCEEDED_TRANSFER_LIMIT);
 		}
 	}

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -279,6 +279,7 @@ public class ProductService {
 			throw new GlobalException(ResultCode.INVALID_DATA_TRANSFER_AMOUNT);
 		}
 
+		System.out.println("member.getSellingData() = " + member.getSellingData());
 		if (member.getSellingData().add(changedDataAmount)
 				.compareTo(BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.EXCEEDED_TRANSFER_LIMIT);

--- a/src/main/java/com/dapanda/trade/controller/TradeController.java
+++ b/src/main/java/com/dapanda/trade/controller/TradeController.java
@@ -2,25 +2,16 @@ package com.dapanda.trade.controller;
 
 import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.common.exception.CommonResponse;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
-import com.dapanda.trade.dto.response.TradeProductResponse;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
 import com.dapanda.trade.service.TradeService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -40,7 +31,7 @@ public class TradeController {
 
 	@GetMapping("/trades/mobile-data/scrap")
 	public CommonResponse<FindMobileDataScrapResponse> defaultPurchaseMobileData(
-			@RequestParam Float dataAmount) {
+			@RequestParam BigDecimal dataAmount) {
 
 		return CommonResponse.success(tradeService.findMobileDataScrap(dataAmount));
 	}

--- a/src/main/java/com/dapanda/trade/dto/MobileDataScrap.java
+++ b/src/main/java/com/dapanda/trade/dto/MobileDataScrap.java
@@ -1,9 +1,8 @@
 package com.dapanda.trade.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
@@ -15,8 +14,8 @@ public class MobileDataScrap {
 	private String memberName;
 	private int price;
 	private int purchasePrice;
-	private float remainAmount;
-	private float purchaseAmount;
+	private BigDecimal remainAmount;
+	private BigDecimal purchaseAmount;
 	private int pricePer100MB;
 	private boolean splitType;
 	private LocalDateTime updatedAt;

--- a/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
+++ b/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
@@ -1,10 +1,9 @@
 package com.dapanda.trade.dto;
 
 import com.dapanda.trade.entity.TradeType;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
@@ -13,7 +12,7 @@ public class PurchaseHistorySummary {
 
 	private Long tradeId;
 	private TradeType tradeType;
-	private float dataAmount; // 데이터 상품
+	private BigDecimal dataAmount; // 데이터 상품
 	private String title; // 와이파이 상품
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dapanda/trade/dto/request/DefaultPurchaseMobileDataRequest.java
+++ b/src/main/java/com/dapanda/trade/dto/request/DefaultPurchaseMobileDataRequest.java
@@ -1,6 +1,7 @@
 package com.dapanda.trade.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 
 public record DefaultPurchaseMobileDataRequest(
 
@@ -10,6 +11,6 @@ public record DefaultPurchaseMobileDataRequest(
 		@NotNull(message = "데이터 아이디는 필수입니다.")
 		Long mobileDataId,
 
-		Float dataAmount) {
+		BigDecimal dataAmount) {
 
 }

--- a/src/main/java/com/dapanda/trade/dto/request/ScrapPurchaseMobileDataRequest.java
+++ b/src/main/java/com/dapanda/trade/dto/request/ScrapPurchaseMobileDataRequest.java
@@ -3,12 +3,13 @@ package com.dapanda.trade.dto.request;
 import com.dapanda.trade.dto.MobileDataScrap;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record ScrapPurchaseMobileDataRequest(
 
 		@NotNull(message = "총 데이터양은 필수입니다.")
-		Float totalAmount,
+		BigDecimal totalAmount,
 
 		@NotNull(message = "총 가격은 필수입니다.")
 		@Min(1)

--- a/src/main/java/com/dapanda/trade/dto/response/FindMobileDataScrapResponse.java
+++ b/src/main/java/com/dapanda/trade/dto/response/FindMobileDataScrapResponse.java
@@ -1,12 +1,9 @@
 package com.dapanda.trade.dto.response;
 
 import com.dapanda.trade.dto.MobileDataScrap;
+import java.math.BigDecimal;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -14,11 +11,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindMobileDataScrapResponse {
 
-	private float totalAmount;
+	private BigDecimal totalAmount;
 	private int totalPrice;
 	private List<MobileDataScrap> combinations;
 
-	public static FindMobileDataScrapResponse of(float totalAmount, int totalPrice,
+	public static FindMobileDataScrapResponse of(BigDecimal totalAmount, int totalPrice,
 			List<MobileDataScrap> combinations) {
 
 		return FindMobileDataScrapResponse.builder()

--- a/src/main/java/com/dapanda/trade/entity/Trade.java
+++ b/src/main/java/com/dapanda/trade/entity/Trade.java
@@ -2,20 +2,9 @@ package com.dapanda.trade.entity;
 
 import com.dapanda.common.entity.CreatedAtEntity;
 import com.dapanda.member.entity.Member;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import lombok.*;
 
 @Entity
 @Getter
@@ -28,7 +17,7 @@ public class Trade extends CreatedAtEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Float dataAmount;
+	private BigDecimal dataAmount;
 
 	private Integer timeAmount;
 
@@ -41,7 +30,7 @@ public class Trade extends CreatedAtEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	public static Trade of(Float dataAmount, Integer timeAmount, int tradingPrice,
+	public static Trade of(BigDecimal dataAmount, Integer timeAmount, int tradingPrice,
 			TradeType tradeType, Member member) {
 
 		return Trade.builder()
@@ -53,7 +42,8 @@ public class Trade extends CreatedAtEntity {
 				.build();
 	}
 
-	public static Trade of(Float dataAmount, int tradingPrice, TradeType tradeType, Member member) {
+	public static Trade of(BigDecimal dataAmount, int tradingPrice, TradeType tradeType,
+			Member member) {
 
 		return Trade.builder()
 				.dataAmount(dataAmount)

--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
@@ -7,18 +7,13 @@ import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
 
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.entity.ItemType;
-import com.dapanda.trade.dto.CashHistoryMonthlySummary;
-import com.dapanda.trade.dto.CashHistorySummary;
-import com.dapanda.trade.dto.PurchaseHistorySummary;
+import com.dapanda.trade.dto.*;
 import com.dapanda.trade.entity.TradeType;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.math.BigDecimal;
+import java.time.*;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -37,7 +32,7 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 				.select(Projections.constructor(PurchaseHistorySummary.class,
 						trade.id,
 						trade.tradeType,
-						trade.dataAmount.coalesce(0f),
+						trade.dataAmount.coalesce(new BigDecimal("0")),
 						wifi.title.coalesce(""),
 						trade.createdAt
 				))
@@ -93,7 +88,7 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 										TradeType.MOBILE_PURCHASE_COMPOSITE))
 								// SQL 문자열 연결 연산자 이용
 								.then(Expressions.stringTemplate("'' || {0}",
-										trade.dataAmount.coalesce(0F)))
+										trade.dataAmount.coalesce(BigDecimal.ZERO)))
 								.when(trade.tradeType.eq(TradeType.WIFI))
 								.then(Expressions.stringTemplate("'' || {0}",
 										trade.timeAmount.coalesce(0)))

--- a/src/main/java/com/dapanda/trade/service/TradeService.java
+++ b/src/main/java/com/dapanda/trade/service/TradeService.java
@@ -7,36 +7,19 @@ import com.dapanda.member.entity.Member;
 import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
-import com.dapanda.trade.dto.CashHistoryMonthlySummary;
-import com.dapanda.trade.dto.CashHistorySummary;
-import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.PurchaseHistorySummary;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
-import com.dapanda.trade.dto.response.TradeProductResponse;
-import com.dapanda.trade.entity.Trade;
-import com.dapanda.trade.entity.TradeDetails;
-import com.dapanda.trade.entity.TradeType;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
+import com.dapanda.trade.dto.*;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
+import com.dapanda.trade.entity.*;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
 import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -84,7 +67,11 @@ public class TradeService {
 
 		if (mobileData.isSplitType()) {
 
-			int price = (int) (mobileData.getPricePer100MB() * request.dataAmount() * 10);
+			int price = BigDecimal.valueOf(mobileData.getPricePer100MB())
+					.multiply(request.dataAmount())
+					.multiply(BigDecimal.TEN)
+					.setScale(0, RoundingMode.CEILING)
+					.intValue();
 
 			return handlePartialPurchaseProduct(product, mobileData, buyerId, request.dataAmount(),
 					price);
@@ -121,7 +108,7 @@ public class TradeService {
 	 * 데이터 분할 상품 일반 구매
 	 */
 	private TradeProductResponse handlePartialPurchaseProduct(Product product,
-			MobileData mobileData, Long buyerId, float dataAmount, int price) {
+			MobileData mobileData, Long buyerId, BigDecimal dataAmount, int price) {
 
 		// Lock 건 상태로 구매자, 판매자 조회
 		Member buyer = memberRepository.findByIdForUpdate(buyerId).orElseThrow();
@@ -140,17 +127,18 @@ public class TradeService {
 		return TradeProductResponse.of(trade.getId());
 	}
 
-	private void validatePurchaseLimit(Member buyer, float dataAmount) {
+	private void validatePurchaseLimit(Member buyer, BigDecimal dataAmount) {
 
-		if (buyer.getBuyingData() + dataAmount > MobileData.MAX_TRANSFERABLE_DATA_AMOUNT) {
+		if (buyer.getBuyingData().add(dataAmount).compareTo(
+				BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.EXCEEDED_PURCHASE_LIMIT);
 		}
 	}
 
 	private void deductBuyerCashAndUpdateState(Member buyer, Product product, MobileData mobileData,
-			int price, float dataAmount) {
+			int price, BigDecimal dataAmount) {
 
-		if (mobileData.getRemainAmount() < dataAmount) {
+		if (mobileData.getRemainAmount().compareTo(dataAmount) < 0) {
 			throw new GlobalException(ResultCode.INVALID_REMAIN_DATA_AMOUNT);
 		}
 		if (buyer.getCash() < price) {
@@ -160,7 +148,7 @@ public class TradeService {
 		buyer.deductCash(price);
 		buyer.addBuyingData(dataAmount);
 		mobileData.deductRemainAmount(dataAmount);
-		if (mobileData.getRemainAmount() == 0) {
+		if (mobileData.getRemainAmount().compareTo(BigDecimal.ZERO) == 0) {
 			product.changeState(ProductState.SOLD_OUT);
 		}
 	}
@@ -180,7 +168,7 @@ public class TradeService {
 		return buyerTrade;
 	}
 
-	private void updateBuyerAndSellerData(Member buyer, Member seller, float dataAmount) {
+	private void updateBuyerAndSellerData(Member buyer, Member seller, BigDecimal dataAmount) {
 
 		seller.addSellingData(dataAmount);
 
@@ -191,7 +179,7 @@ public class TradeService {
 		sellerPlan.deductMobileData(dataAmount);
 	}
 
-	public FindMobileDataScrapResponse findMobileDataScrap(Float dataAmount) {
+	public FindMobileDataScrapResponse findMobileDataScrap(BigDecimal dataAmount) {
 
 		// 1. 정렬된 상품 목록 조회 (단가 낮은순, 용량 많은순, 일반우선)
 		List<MobileDataScrap> sortedList = productRepository.findMobileDataScrap(dataAmount);
@@ -199,22 +187,22 @@ public class TradeService {
 		// 2. 가능한 조합들을 저장할 리스트
 		List<List<MobileDataScrap>> candidates = new ArrayList<>(); // 가능한 조합들을 저장하는 리스트
 		int sortedListSize = sortedList.size();
-		float target = dataAmount; // 사용자가 구매하고자 하는 목표 데이터 용량 (GB 단위)
+		BigDecimal target = dataAmount; // 사용자가 구매하고자 하는 목표 데이터 용량 (GB 단위)
 
 		// 3. 시작 인덱스를 0부터 n-1까지 순차적으로 이동하며 탐색
 		for (int start = 0; start < sortedListSize; start++) {
-			float sumAmount = 0; // 현재 조합에 포함된 상품들로 누적한 총 데이터 용량 (GB 단위)
+			BigDecimal sumAmount = BigDecimal.ZERO; // 현재 조합에 포함된 상품들로 누적한 총 데이터 용량 (GB 단위)
 			int sumPrice = 0;
 			List<MobileDataScrap> temp = new ArrayList<>(); // 현재 조합 중인 상품 목록을 저장하는 임시 리스트
 
 			// 4. 현재 start 위치부터 하나씩 상품을 누적하며 조합을 시도
 			for (int i = start; i < sortedListSize; i++) {
 				MobileDataScrap item = sortedList.get(i);
-				float amount = item.getRemainAmount();
+				BigDecimal amount = item.getRemainAmount();
 
 				// 4-1. 분할 가능한 상품이고, 목표 용량을 초과한다면 필요한 만큼만 구매
 				if (item.isSplitType()) {
-					float needed = Math.min(amount, target - sumAmount);
+					BigDecimal needed = amount.min(target.subtract(sumAmount));
 
 					// 필요한 만큼만 구매한 정보로 새 객체 생성
 					MobileDataScrap partialScrap = new MobileDataScrap(
@@ -222,7 +210,8 @@ public class TradeService {
 							item.getMobileDataId(),
 							item.getMemberName(),
 							item.getPrice(),
-							(int) (needed * 10 * item.getPricePer100MB()), // purchasePrice
+							(int) (needed.doubleValue() * 10 * item.getPricePer100MB()),
+							// purchasePrice
 							item.getRemainAmount(),
 							needed, // purchaseAmount
 							item.getPricePer100MB(),
@@ -230,20 +219,20 @@ public class TradeService {
 							item.getUpdatedAt()
 					);
 
-					sumAmount += needed;
-					sumPrice += (int) (needed * 10 * item.getPricePer100MB());
+					sumAmount = sumAmount.add(needed);
+					sumPrice += (int) (needed.doubleValue() * 10 * item.getPricePer100MB());
 					temp.add(partialScrap);
 				} else {
-					sumAmount += amount;
+					sumAmount = sumAmount.add(amount);
 					sumPrice += item.getPrice();
 					temp.add(item);
 				}
 
-				if (sumAmount == target) { // 5. 목표 용량을 정확히 채운 조합은 후보군에 추가
+				if (sumAmount.compareTo(target) == 0) { // 5. 목표 용량을 정확히 채운 조합은 후보군에 추가
 					candidates.add(temp);
 					break;
 				}
-				if (sumAmount > target) { // 6. 목표 용량을 초과하면 더 이상 탐색하지 않음
+				if (sumAmount.compareTo(target) > 0) { // 6. 목표 용량을 초과하면 더 이상 탐색하지 않음
 					break;
 				}
 			}
@@ -262,7 +251,7 @@ public class TradeService {
 		// 9. 후보가 없으면 빈 응답 반환
 		if (best.isEmpty()) {
 
-			return FindMobileDataScrapResponse.of(0, 0, Collections.emptyList());
+			return FindMobileDataScrapResponse.of(BigDecimal.ZERO, 0, Collections.emptyList());
 		}
 
 		// 10. 최적 조합이 존재하면 최종 응답 생성
@@ -272,25 +261,25 @@ public class TradeService {
 		return FindMobileDataScrapResponse.of(dataAmount, totalPrice, bestCombination);
 	}
 
-	private int calculateTotalPrice(List<MobileDataScrap> scrapList, float dataAmount) {
+	private int calculateTotalPrice(List<MobileDataScrap> scrapList, BigDecimal dataAmount) {
 
-		float sumAmount = 0;
+		BigDecimal sumAmount = BigDecimal.ZERO;
 		int total = 0;
 
 		// 조합된 상품 리스트를 순회하며, 실제로 필요한 만큼만 구매하고 총 가격 계산
 		for (MobileDataScrap scrap : scrapList) {
 			// 분할 상품의 경우: 필요한 만큼만 구매 (단가 적용)
 			if (scrap.isSplitType()) {
-				float needed = Math.min(scrap.getRemainAmount(), dataAmount - sumAmount);
-				total += (int) (needed * 10 * scrap.getPricePer100MB());
-				sumAmount += needed;
+				BigDecimal needed = scrap.getRemainAmount().min(dataAmount.subtract(sumAmount));
+				total += (int) (needed.doubleValue() * 10 * scrap.getPricePer100MB());
+				sumAmount = sumAmount.add(needed);
 			} else { // 일반 상품의 경우: 상품 전체를 사용하며 고정 가격 적용
 				total += scrap.getPrice();
-				sumAmount += scrap.getRemainAmount();
+				sumAmount = sumAmount.add(scrap.getRemainAmount());
 			}
 
 			// 목표 용량을 채웠으면 반복 종료
-			if (sumAmount >= dataAmount) {
+			if (sumAmount.compareTo(dataAmount) >= 0) {
 				break;
 			}
 		}
@@ -305,7 +294,7 @@ public class TradeService {
 	public TradeProductResponse scrapPurchaseMobileData(Long buyerId,
 			ScrapPurchaseMobileDataRequest request) {
 
-		float totalAmount = request.totalAmount();
+		BigDecimal totalAmount = request.totalAmount();
 		int totalPrice = request.totalPrice();
 
 		// 1. 구매자 Lock 조회
@@ -335,8 +324,8 @@ public class TradeService {
 					.orElseThrow(() -> new GlobalException(ResultCode.MEMBER_NOT_FOUND));
 
 			// 4-2. 구매 데이터양 만큼 remainAmount 차감
-			float purchaseAmount = scrap.getPurchaseAmount();
-			if (mobileData.getRemainAmount() < purchaseAmount) {
+			BigDecimal purchaseAmount = scrap.getPurchaseAmount();
+			if (mobileData.getRemainAmount().compareTo(purchaseAmount) < 0) {
 				throw new GlobalException(ResultCode.INVALID_REMAIN_DATA_AMOUNT);
 			}
 
@@ -352,7 +341,8 @@ public class TradeService {
 			seller.addSellingData(purchaseAmount);
 
 			// 4-6. 상품 상태 변경
-			if (!mobileData.isSplitType() || mobileData.getRemainAmount() == 0) {
+			if (!mobileData.isSplitType()
+					|| mobileData.getRemainAmount().compareTo(BigDecimal.ZERO) == 0) {
 				product.changeState(ProductState.SOLD_OUT);
 			}
 

--- a/src/test/java/com/dapanda/TestConstants.java
+++ b/src/test/java/com/dapanda/TestConstants.java
@@ -2,6 +2,7 @@ package com.dapanda;
 
 import com.dapanda.report.entity.ReportTargetCategory;
 import com.dapanda.review.entity.ReviewSortOption;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public final class TestConstants {
@@ -65,16 +66,16 @@ public final class TestConstants {
 	public static final class MobileData {
 
 		public static final Long MOBILE_DATA_ID = 1L;
-		public static final float BEFORE_DATA_AMOUNT = 1.0F;
-		public static final float BEFORE_REMAIN_AMOUNT = 1.0F;
-		public static final float CHANGED_AMOUNT = 1.0F;
-		public static final float EXCEED_CHANGED_AMOUNT = 3.0F;
-		public static final float SELLING_DATA = 1.5F;
+		public static final BigDecimal BEFORE_DATA_AMOUNT = BigDecimal.valueOf(1.0);
+		public static final BigDecimal BEFORE_REMAIN_AMOUNT = BigDecimal.valueOf(1.0);
+		public static final BigDecimal CHANGED_AMOUNT = BigDecimal.valueOf(1.0);
+		public static final BigDecimal EXCEED_CHANGED_AMOUNT = BigDecimal.valueOf(3.0);
+		public static final BigDecimal SELLING_DATA = BigDecimal.valueOf(1.5);
 		public static final boolean SPLIT_TYPE = true;
-		public static final float DATA_AMOUNT_1 = 1.0F;
-		public static final float DATA_AMOUNT_2 = 2.0F;
-		public static final float REMAIN_AMOUNT_1 = 1.0F;
-		public static final float REMAIN_AMOUNT_2 = 2.0F;
+		public static final BigDecimal DATA_AMOUNT_1 = BigDecimal.valueOf(1.0);
+		public static final BigDecimal DATA_AMOUNT_2 = BigDecimal.valueOf(2.0);
+		public static final BigDecimal REMAIN_AMOUNT_1 = BigDecimal.valueOf(1.0);
+		public static final BigDecimal REMAIN_AMOUNT_2 = BigDecimal.valueOf(2.0);
 		public static final int PRICE_PER_100MB_300 = 300;
 		public static final int PRICE_PER_100MB_150 = 150;
 	}
@@ -101,7 +102,8 @@ public final class TestConstants {
 
 	public static final class Plan {
 
-		public static final Float PROVIDING_DATA_AMOUNT_10 = 10.0F;
+		public static final BigDecimal PROVIDING_DATA_AMOUNT_10 = BigDecimal.valueOf(10);
+
 	}
 
 	public static final class Chat {

--- a/src/test/java/com/dapanda/TestConstants.java
+++ b/src/test/java/com/dapanda/TestConstants.java
@@ -16,8 +16,8 @@ public final class TestConstants {
 		public static final Long OTHER_MEMBER_ID = 2L;
 		public static final int CASH_3000 = 3000;
 		public static final int CASH_5000 = 5000;
-		public static final float BUYING_DATA = 1F;
-		public static final float SELLING_DATA = 1F;
+		public static final BigDecimal BUYING_DATA = BigDecimal.valueOf(1.0);
+		public static final BigDecimal SELLING_DATA = BigDecimal.valueOf(1.0);
 	}
 
 	public static final class Pagination {

--- a/src/test/java/com/dapanda/member/entity/MemberFixture.java
+++ b/src/test/java/com/dapanda/member/entity/MemberFixture.java
@@ -1,6 +1,7 @@
 package com.dapanda.member.entity;
 
 import com.dapanda.auth.entity.OAuthProvider;
+import java.math.BigDecimal;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class MemberFixture {
@@ -73,7 +74,7 @@ public class MemberFixture {
 		return member;
 	}
 
-	public static Member createMemberWithSellingDataWithId(long memberId, float sellingData) {
+	public static Member createMemberWithSellingDataWithId(long memberId, BigDecimal sellingData) {
 
 		Member member = createMember1WithId(memberId);
 		ReflectionTestUtils.setField(member, "sellingData", sellingData);  // 강제로 세팅
@@ -81,7 +82,7 @@ public class MemberFixture {
 		return member;
 	}
 
-	public static Member createMemberWithSellingData(float sellingData) {
+	public static Member createMemberWithSellingData(BigDecimal sellingData) {
 
 		Member member = createMember1();
 		ReflectionTestUtils.setField(member, "sellingData", sellingData);  // 강제로 세팅

--- a/src/test/java/com/dapanda/member/entity/MemberFixture.java
+++ b/src/test/java/com/dapanda/member/entity/MemberFixture.java
@@ -8,52 +8,77 @@ public class MemberFixture {
 
 	public static Member createMember1() {
 
-		return Member.ofOAuthMember(
+		Member member = Member.ofOAuthMember(
 				"dummy1@email.com",
 				"dummy1Name",
 				OAuthProvider.KAKAO,
 				MemberRole.ROLE_MEMBER
 		);
+
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
+
+		return member;
 	}
 
 	public static Member createMember2() {
 
-		return Member.ofOAuthMember(
+		Member member = Member.ofOAuthMember(
 				"dummy2@email.com",
 				"dummy2Name",
 				OAuthProvider.KAKAO,
 				MemberRole.ROLE_MEMBER
 		);
+
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
+
+		return member;
 	}
 
 	public static Member createMember3() {
 
-		return Member.ofOAuthMember(
+		Member member = Member.ofOAuthMember(
 				"dummy3@email.com",
 				"dummy3Name",
 				OAuthProvider.KAKAO,
 				MemberRole.ROLE_MEMBER
 		);
+
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
+
+		return member;
 	}
 
 	public static Member createMember4() {
 
-		return Member.ofOAuthMember(
+		Member member = Member.ofOAuthMember(
 				"dummy4@email.com",
 				"dummy4Name",
 				OAuthProvider.KAKAO,
 				MemberRole.ROLE_MEMBER
 		);
+
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
+
+		return member;
 	}
 
 	public static Member createMember5() {
 
-		return Member.ofOAuthMember(
+		Member member = Member.ofOAuthMember(
 				"dummy5@email.com",
 				"dummy5Name",
 				OAuthProvider.KAKAO,
 				MemberRole.ROLE_MEMBER
 		);
+
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
+
+		return member;
 	}
 
 	public static Member createMember1WithId(Long memberId) {
@@ -61,6 +86,8 @@ public class MemberFixture {
 		Member member = createMember1();
 
 		ReflectionTestUtils.setField(member, "id", memberId);
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
 
 		return member;
 	}
@@ -70,6 +97,8 @@ public class MemberFixture {
 		Member member = createMember2();
 
 		ReflectionTestUtils.setField(member, "id", memberId);
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
+		ReflectionTestUtils.setField(member, "sellingData", BigDecimal.ZERO);
 
 		return member;
 	}
@@ -77,7 +106,9 @@ public class MemberFixture {
 	public static Member createMemberWithSellingDataWithId(long memberId, BigDecimal sellingData) {
 
 		Member member = createMember1WithId(memberId);
+
 		ReflectionTestUtils.setField(member, "sellingData", sellingData);  // 강제로 세팅
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
 
 		return member;
 	}
@@ -85,7 +116,9 @@ public class MemberFixture {
 	public static Member createMemberWithSellingData(BigDecimal sellingData) {
 
 		Member member = createMember1();
+
 		ReflectionTestUtils.setField(member, "sellingData", sellingData);  // 강제로 세팅
+		ReflectionTestUtils.setField(member, "buyingData", BigDecimal.ZERO);
 
 		return member;
 	}

--- a/src/test/java/com/dapanda/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/dapanda/plan/controller/PlanControllerTest.java
@@ -94,7 +94,7 @@ class PlanControllerTest {
 				// given
 				Plan plan = planRepository.save(Plan.of(
 						"청년 Value 베이직",
-						BigDecimal.valueOf(30),
+						BigDecimal.valueOf(30.0),
 						15000,
 						PlanCategory._5G,
 						AgeGroup.YOUTH,
@@ -131,7 +131,8 @@ class PlanControllerTest {
 
 				// 실제 서비스로직 검증 (Optional)
 				var result = planRepository.findByMemberId(member.getId()).orElseThrow();
-				assertThat(result.getProvidingDataAmount()).isEqualTo(30.0f);
+				assertThat(result.getProvidingDataAmount()).isEqualByComparingTo(
+						BigDecimal.valueOf(30.0));
 			}
 		}
 

--- a/src/test/java/com/dapanda/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/dapanda/plan/controller/PlanControllerTest.java
@@ -13,16 +13,12 @@ import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.member.entity.Member;
 import com.dapanda.member.entity.MemberFixture;
 import com.dapanda.member.repository.MemberRepository;
-import com.dapanda.plan.entity.AgeGroup;
-import com.dapanda.plan.entity.Plan;
-import com.dapanda.plan.entity.PlanCategory;
+import com.dapanda.plan.entity.*;
 import com.dapanda.plan.repository.PlanRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -98,7 +94,7 @@ class PlanControllerTest {
 				// given
 				Plan plan = planRepository.save(Plan.of(
 						"청년 Value 베이직",
-						30.0f,
+						BigDecimal.valueOf(30),
 						15000,
 						PlanCategory._5G,
 						AgeGroup.YOUTH,

--- a/src/test/java/com/dapanda/plan/entity/PlanFixture.java
+++ b/src/test/java/com/dapanda/plan/entity/PlanFixture.java
@@ -1,10 +1,11 @@
 package com.dapanda.plan.entity;
 
 import com.dapanda.member.entity.Member;
+import java.math.BigDecimal;
 
 public class PlanFixture {
 
-	public static Plan createPlan(Member member, Float providingDataAmount) {
+	public static Plan createPlan(Member member, BigDecimal providingDataAmount) {
 
 		return Plan.of("요금제", providingDataAmount, 30000, PlanCategory._5G, AgeGroup.ANY,
 				member);

--- a/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
@@ -1,28 +1,17 @@
 package com.dapanda.plan.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.dapanda.member.entity.Member;
 import com.dapanda.plan.dto.response.PlanInfoResponse;
-import com.dapanda.plan.entity.AgeGroup;
-import com.dapanda.plan.entity.Plan;
-import com.dapanda.plan.entity.PlanCategory;
+import com.dapanda.plan.entity.*;
 import com.dapanda.plan.repository.PlanRepository;
+import java.math.BigDecimal;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,7 +104,7 @@ class PlanServiceTest {
 
 				when(planRepository.findByMemberId(memberId)).thenReturn(Optional.of(plan));
 				when(plan.getName()).thenReturn("프리미엄");
-				when(plan.getProvidingDataAmount()).thenReturn(30.0f);
+				when(plan.getProvidingDataAmount()).thenReturn(BigDecimal.valueOf(30));
 				when(plan.getMonthlyPrice()).thenReturn(25000);
 
 				// when

--- a/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
@@ -104,7 +104,7 @@ class PlanServiceTest {
 
 				when(planRepository.findByMemberId(memberId)).thenReturn(Optional.of(plan));
 				when(plan.getName()).thenReturn("프리미엄");
-				when(plan.getProvidingDataAmount()).thenReturn(BigDecimal.valueOf(30));
+				when(plan.getProvidingDataAmount()).thenReturn(BigDecimal.valueOf(30.0));
 				when(plan.getMonthlyPrice()).thenReturn(25000);
 
 				// when
@@ -113,7 +113,8 @@ class PlanServiceTest {
 				// then
 				assertThat(result).isNotNull();
 				assertThat(result.getName()).isEqualTo("프리미엄");
-				assertThat(result.getProvidingDataAmount()).isEqualTo(30.0f);
+				assertThat(result.getProvidingDataAmount()).isEqualByComparingTo(
+						BigDecimal.valueOf(30.0));
 				assertThat(result.getMonthlyPrice()).isEqualTo(25000);
 				verify(planRepository, times(1)).findByMemberId(memberId);
 			}

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -32,6 +32,7 @@ import com.dapanda.product.repository.*;
 import com.dapanda.product.service.ProductService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
 import org.junit.jupiter.api.*;
@@ -49,31 +50,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static com.dapanda.TestConstants.Member.USER_DETAILS_MEMBER_ID;
-import static com.dapanda.TestConstants.MobileData.*;
-import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
-import static com.dapanda.TestConstants.Product.*;
-import static com.dapanda.TestConstants.Wifi.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -147,7 +123,8 @@ class ProductControllerTest {
 			@DisplayName("정상적으로 모바일 데이터 상품을 등록한다")
 			void createMobileData_success() throws Exception {
 
-				CreateMobileDataRequest request = new CreateMobileDataRequest(12000, 2.0F, false);
+				CreateMobileDataRequest request = new CreateMobileDataRequest(12000,
+						new BigDecimal("2.0"), false);
 
 				mockMvc.perform(MockMvcRequestBuilders.post("/api/products/mobile-data")
 								.with(authentication(new UsernamePasswordAuthenticationToken(
@@ -232,7 +209,7 @@ class ProductControllerTest {
 				Member member = memberRepository.save(MemberFixture.createMember2());
 				// sellingData 필드를 강제로 세팅하려면 set 메소드 또는 ReflectionTestUtils 사용
 				MobileData fullMobileData = mobileDataRepository.save(
-						MobileData.singleOf(2000F, 1000, false) // 2000MB짜리 상품
+						MobileData.singleOf(BigDecimal.valueOf(2000), 1000, false) // 2000MB짜리 상품
 				);
 				productRepository.save(
 						Product.of(ProductState.ACTIVE, 1000, fullMobileData.getId(),
@@ -241,7 +218,8 @@ class ProductControllerTest {
 
 				userDetails = CustomUserDetails.from(member);
 
-				CreateMobileDataRequest request = new CreateMobileDataRequest(12000, 1.0F, false);
+				CreateMobileDataRequest request = new CreateMobileDataRequest(12000,
+						BigDecimal.valueOf(1.0), false);
 
 				mockMvc.perform(MockMvcRequestBuilders.post("/api/products/mobile-data")
 								.with(authentication(new UsernamePasswordAuthenticationToken(
@@ -271,7 +249,7 @@ class ProductControllerTest {
 
 				CreateMobileDataRequest incompleteRequest = new CreateMobileDataRequest(
 						null,     // price 누락
-						2.0F,
+						new BigDecimal("2.0"),
 						false
 				);
 
@@ -372,13 +350,16 @@ class ProductControllerTest {
 				// given
 				int size = 2;
 				String productSortOption = "RECENT";
-				Float dataAmount = 2.0F;
+				BigDecimal dataAmount = new BigDecimal("2.0");
 
 				Member member = memberRepository.save(MemberFixture.createMember1());
 
-				MobileData mobileData1 = MobileDataFixture.createMobileData(2.0F, 2.0F, 500);
-				MobileData mobileData2 = MobileDataFixture.createMobileData(2.0F, 2.0F, 600);
-				MobileData mobileData3 = MobileDataFixture.createMobileData(3.0F, 3.0F, 700);
+				MobileData mobileData1 = MobileDataFixture.createMobileData(BigDecimal.valueOf(2.0),
+						BigDecimal.valueOf(2.0), 500);
+				MobileData mobileData2 = MobileDataFixture.createMobileData(BigDecimal.valueOf(2.0),
+						BigDecimal.valueOf(2.0), 600);
+				MobileData mobileData3 = MobileDataFixture.createMobileData(BigDecimal.valueOf(3.0),
+						BigDecimal.valueOf(3.0), 700);
 				mobileDataRepository.saveAll(List.of(mobileData1, mobileData2, mobileData3));
 
 				Product product1 = ProductFixture.createMobileDataProduct(3000,
@@ -948,9 +929,9 @@ class ProductControllerTest {
 				assertThat(updatedProduct.getId()).isEqualTo(product.getId());
 				assertThat(updatedProduct.getPrice()).isEqualTo(NEW_PRICE_9000);
 				assertThat(updatedMobileData.getDataAmount()).isEqualTo(
-						BEFORE_DATA_AMOUNT + CHANGED_AMOUNT);
+						BEFORE_DATA_AMOUNT.add(CHANGED_AMOUNT));
 				assertThat(updatedMobileData.getRemainAmount()).isEqualTo(
-						BEFORE_REMAIN_AMOUNT + CHANGED_AMOUNT);
+						BEFORE_REMAIN_AMOUNT.add(CHANGED_AMOUNT));
 			}
 		}
 

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -402,7 +402,7 @@ class ProductControllerTest {
 										fieldWithPath("message").description("처리 결과 메시지"),
 										fieldWithPath("data").description("응답 데이터 (에러시 반환되지 않음)"),
 										fieldWithPath("data.data").description("상품 데이터 배열"),
-										fieldWithPath("data.data[].id").description(
+										fieldWithPath("data.data[].productId").description(
 												"상품 아이디"),
 										fieldWithPath("data.data[].price").description(
 												"상품 가격"),
@@ -547,7 +547,7 @@ class ProductControllerTest {
 										fieldWithPath("message").description("처리 결과 메시지"),
 										fieldWithPath("data").description("응답 데이터 (에러시 반환되지 않음)"),
 										fieldWithPath("data.data").description("상품 데이터 배열"),
-										fieldWithPath("data.data[].id").description(
+										fieldWithPath("data.data[].productId").description(
 												"상품 아이디"),
 										fieldWithPath("data.data[].price").description(
 												"상품 가격"),
@@ -684,7 +684,7 @@ class ProductControllerTest {
 
 				assertThat(actualResponse.getProductId()).isEqualTo(PRODUCT_ID);
 				assertThat(actualResponse.getItemId()).isEqualTo(mobileData.getId());
-				assertThat(actualResponse.getRemainAmount()).isEqualTo(REMAIN_AMOUNT_1);
+				assertThat(actualResponse.getRemainAmount()).isEqualByComparingTo(REMAIN_AMOUNT_1);
 				assertThat(actualResponse.getPricePer100MB()).isEqualTo(PRICE_PER_100MB_300);
 			}
 		}
@@ -928,9 +928,9 @@ class ProductControllerTest {
 
 				assertThat(updatedProduct.getId()).isEqualTo(product.getId());
 				assertThat(updatedProduct.getPrice()).isEqualTo(NEW_PRICE_9000);
-				assertThat(updatedMobileData.getDataAmount()).isEqualTo(
+				assertThat(updatedMobileData.getDataAmount()).isEqualByComparingTo(
 						BEFORE_DATA_AMOUNT.add(CHANGED_AMOUNT));
-				assertThat(updatedMobileData.getRemainAmount()).isEqualTo(
+				assertThat(updatedMobileData.getRemainAmount()).isEqualByComparingTo(
 						BEFORE_REMAIN_AMOUNT.add(CHANGED_AMOUNT));
 			}
 		}

--- a/src/test/java/com/dapanda/product/entity/MobileDataFixture.java
+++ b/src/test/java/com/dapanda/product/entity/MobileDataFixture.java
@@ -1,13 +1,14 @@
 package com.dapanda.product.entity;
 
 import com.dapanda.product.dto.MobileDataSummary;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class MobileDataFixture {
 
-	public static MobileData createMobileData(float dataAmount, float remainAmount,
+	public static MobileData createMobileData(BigDecimal dataAmount, BigDecimal remainAmount,
 			int pricePer100MB) {
 
 		return MobileData.of(
@@ -18,8 +19,8 @@ public class MobileDataFixture {
 		);
 	}
 
-	public static MobileData createMobileDataWithId(Long mobileDataId, float dataAmount,
-			float remainAmount, int pricePer100MB) {
+	public static MobileData createMobileDataWithId(Long mobileDataId, BigDecimal dataAmount,
+			BigDecimal remainAmount, int pricePer100MB) {
 
 		MobileData mobileData = MobileData.of(
 				dataAmount,
@@ -33,7 +34,8 @@ public class MobileDataFixture {
 		return mobileData;
 	}
 
-	public static MobileData createMobileDataSplitType(float dataAmount, float remainAmount,
+	public static MobileData createMobileDataSplitType(BigDecimal dataAmount,
+			BigDecimal remainAmount,
 			int pricePer100MB) {
 
 		return MobileData.of(
@@ -44,8 +46,9 @@ public class MobileDataFixture {
 		);
 	}
 
-	public static MobileData createMobileDataSplitTypeWithId(Long mobileDataId, float dataAmount,
-			float remainAmount,
+	public static MobileData createMobileDataSplitTypeWithId(Long mobileDataId,
+			BigDecimal dataAmount,
+			BigDecimal remainAmount,
 			int pricePer100MB) {
 
 		MobileData mobileData = MobileData.of(
@@ -63,22 +66,22 @@ public class MobileDataFixture {
 	public static List<MobileData> createMobileDataList() {
 
 		return List.of(
-				MobileData.of(1001, 500, 100, false),
-				MobileData.of(1002, 500, 100, false),
-				MobileData.of(1003, 500, 100, false),
-				MobileData.of(1004, 500, 100, false),
-				MobileData.of(1005, 500, 100, false),
-				MobileData.of(1006, 500, 100, false),
-				MobileData.of(1007, 500, 100, false),
-				MobileData.of(1008, 500, 100, false),
-				MobileData.of(1009, 500, 100, false),
-				MobileData.of(1010, 500, 100, false),
-				MobileData.of(1011, 500, 100, false)
+				MobileData.of(BigDecimal.valueOf(1001), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1002), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1003), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1004), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1005), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1006), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1007), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1008), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1009), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1010), BigDecimal.valueOf(500), 100, false),
+				MobileData.of(BigDecimal.valueOf(1011), BigDecimal.valueOf(500), 100, false)
 		);
 	}
 
 	public static MobileDataSummary createMobileDataSummary(Long id, int price, Long itemId,
-			String memberName, float remainAmount, int pricePer100MB, boolean isSplitType,
+			String memberName, BigDecimal remainAmount, int pricePer100MB, boolean isSplitType,
 			LocalDateTime updatedAt) {
 
 		return new MobileDataSummary(

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -266,62 +266,8 @@ class ProductServiceTest {
 
 				// then
 				assertThat(result.getData()).hasSize(3);
-				assertThat(result.getData().get(0).getRemainAmount()).isEqualTo(2);
-			}
-
-			@Test
-			@DisplayName("AMOUNT_DESC 정렬로 데이터 상품 목록 조회를 성공한다")
-			void findMobileDataSortedByAmountDescTest() {
-
-				// given
-				List<MobileDataSummary> summaries = new ArrayList<>();
-				for (int i = 3; i >= 1; i--) {
-					summaries.add(
-							MobileDataFixture.createMobileDataSummary((long) i, 1000, (long) i,
-									"회원" + i,
-									BigDecimal.valueOf(10).multiply(BigDecimal.valueOf(i)), 200,
-									false, UPDATED_AT));
-				}
-				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
-						CursorPageResponse.PageInfo.of(3L, false, 3));
-
-				given(productRepository.findMobileDataByCursor(null, 3,
-						ProductSortOption.AMOUNT_DESC, null)).willReturn(response);
-
-				// when
-				CursorPageResponse<MobileDataSummary> result = productService.findMobileDataByCursor(
-						null, 3, "AMOUNT_DESC", null);
-
-				// then
-				assertThat(result.getData()).hasSize(3);
-				assertThat(result.getData().get(0).getRemainAmount()).isEqualTo(30);
-			}
-
-			@Test
-			@DisplayName("dataAmount 기준으로 필터링된 데이터 상품 목록 조회를 성공한다")
-			void findMobileDataFilteredByAmountTest() {
-
-				// given
-				List<MobileDataSummary> summaries = new ArrayList<>();
-				summaries.add(new MobileDataSummary(1L, 1000, 1L, "회원1", new BigDecimal("2.0"), 200,
-						false, UPDATED_AT));
-				summaries.add(
-						new MobileDataSummary(2L, 2000, 2L, "회원2", new BigDecimal("5.0"), 200,
-								false, UPDATED_AT));
-				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
-						CursorPageResponse.PageInfo.of(2L, false, 2));
-
-				given(productRepository.findMobileDataByCursor(null, 3,
-						ProductSortOption.AMOUNT_ASC, new BigDecimal("5.0"))).willReturn(response);
-
-				// when
-				CursorPageResponse<MobileDataSummary> result = productService.findMobileDataByCursor(
-						null, 3, "AMOUNT_ASC", new BigDecimal("5.0"));
-
-				// then
-				assertThat(result.getData()).hasSize(2);
-				assertThat(Optional.of(
-						result.getData().get(0).getRemainAmount())).isEqualTo(5);
+				assertThat(result.getData().get(0).getRemainAmount()).isEqualByComparingTo(
+						BigDecimal.valueOf(3));
 			}
 		}
 
@@ -742,8 +688,7 @@ class ProductServiceTest {
 
 				// given
 				UpdateMobileDataRequest request = new UpdateMobileDataRequest(PRODUCT_ID,
-						NEW_PRICE_9000,
-						CHANGED_AMOUNT, SPLIT_TYPE);
+						NEW_PRICE_9000, CHANGED_AMOUNT, SPLIT_TYPE);
 
 				Member member = MemberFixture.createMemberWithSellingDataWithId(MEMBER_ID,
 						SELLING_DATA);

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -1,8 +1,8 @@
 package com.dapanda.product.service;
 
 import static com.dapanda.TestConstants.Member.*;
-import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.MobileData.*;
+import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_CURSOR_ID;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Product.*;
@@ -28,6 +28,7 @@ import com.dapanda.product.dto.request.*;
 import com.dapanda.product.dto.response.*;
 import com.dapanda.product.entity.*;
 import com.dapanda.product.repository.*;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
 import org.junit.jupiter.api.*;
@@ -69,12 +70,14 @@ class ProductServiceTest {
 			// given
 			Long memberId = 1L;
 			Member member = MemberFixture.createMember1WithId(memberId);
-			CreateMobileDataRequest request = new CreateMobileDataRequest(12000, 1.0F, false);
+			CreateMobileDataRequest request = new CreateMobileDataRequest(12000,
+					BigDecimal.valueOf(1.0), false);
 
 			given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-			given(productRepository.sumSoldMobileDataAmountByMemberId(memberId)).willReturn(1.0F);
+			given(productRepository.sumSoldMobileDataAmountByMemberId(memberId)).willReturn(
+					BigDecimal.valueOf(1.0));
 
-			MobileData mobileData = MobileData.singleOf(1.0F, 12000, false);
+			MobileData mobileData = MobileData.singleOf(new BigDecimal("1.0"), 12000, false);
 			given(mobileDataRepository.save(any())).willReturn(mobileData);
 
 			Product product = Product.of(ProductState.ACTIVE, 12000, 1L, ItemType.MOBILE_DATA,
@@ -92,7 +95,8 @@ class ProductServiceTest {
 
 			// given
 			Long memberId = 1234L;
-			CreateMobileDataRequest request = new CreateMobileDataRequest(12000, 2.0F, false);
+			CreateMobileDataRequest request = new CreateMobileDataRequest(12000,
+					new BigDecimal("1.0"), false);
 
 			given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
@@ -109,12 +113,13 @@ class ProductServiceTest {
 			// given
 			Long memberId = 1L;
 			Member member = MemberFixture.createMember1WithId(memberId);
-			CreateMobileDataRequest request = new CreateMobileDataRequest(12000, 2000.0F,
+			CreateMobileDataRequest request = new CreateMobileDataRequest(12000,
+					new BigDecimal("2000.0"),
 					false); // 2GB 추가
 
 			given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 			given(productRepository.sumSoldMobileDataAmountByMemberId(memberId)).willReturn(
-					2000.0F);
+					BigDecimal.valueOf(2000));
 
 			// when/then
 			assertThatThrownBy(() -> productService.createMobileData(request, memberId))
@@ -185,7 +190,7 @@ class ProductServiceTest {
 				for (int i = 1; i <= 3; i++) {
 					summaries.add(
 							MobileDataFixture.createMobileDataSummary((long) i, 1000, (long) i,
-									"회원" + i, 5, 200, false, UPDATED_AT));
+									"회원" + i, new BigDecimal("5.0"), 200, false, UPDATED_AT));
 				}
 				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(3L, false, 3));
@@ -210,7 +215,7 @@ class ProductServiceTest {
 				for (int i = 1; i <= 3; i++) {
 					summaries.add(
 							MobileDataFixture.createMobileDataSummary((long) i, 100 + i, (long) i,
-									"회원" + i, 5, 200, false, UPDATED_AT));
+									"회원" + i, BigDecimal.valueOf(5), 200, false, UPDATED_AT));
 				}
 				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(3L, false, 3));
@@ -240,7 +245,7 @@ class ProductServiceTest {
 							(100 + 100 * i) * 10 * i,
 							(long) i,
 							"회원" + i,
-							1 + i,
+							new BigDecimal(String.valueOf(2.0 + i)),
 							100 + 100 * i,
 							i % 2 == 0,
 							UPDATED_AT
@@ -253,11 +258,11 @@ class ProductServiceTest {
 				);
 
 				given(productRepository.findMobileDataByCursor(null, 2,
-						ProductSortOption.AMOUNT_ASC, 2.0F)).willReturn(response);
+						ProductSortOption.AMOUNT_ASC, new BigDecimal("2.0"))).willReturn(response);
 
 				// when
 				CursorPageResponse<MobileDataSummary> result = productService.findMobileDataByCursor(
-						null, 2, "AMOUNT_ASC", 2.0F);
+						null, 2, "AMOUNT_ASC", new BigDecimal("2.0"));
 
 				// then
 				assertThat(result.getData()).hasSize(3);
@@ -273,7 +278,9 @@ class ProductServiceTest {
 				for (int i = 3; i >= 1; i--) {
 					summaries.add(
 							MobileDataFixture.createMobileDataSummary((long) i, 1000, (long) i,
-									"회원" + i, i * 10, 200, false, UPDATED_AT));
+									"회원" + i,
+									BigDecimal.valueOf(10).multiply(BigDecimal.valueOf(i)), 200,
+									false, UPDATED_AT));
 				}
 				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(3L, false, 3));
@@ -296,24 +303,25 @@ class ProductServiceTest {
 
 				// given
 				List<MobileDataSummary> summaries = new ArrayList<>();
-				summaries.add(new MobileDataSummary(1L, 1000, 1L, "회원1", 5.0F, 200,
+				summaries.add(new MobileDataSummary(1L, 1000, 1L, "회원1", new BigDecimal("2.0"), 200,
 						false, UPDATED_AT));
 				summaries.add(
-						new MobileDataSummary(2L, 2000, 2L, "회원2", 10, 200,
+						new MobileDataSummary(2L, 2000, 2L, "회원2", new BigDecimal("5.0"), 200,
 								false, UPDATED_AT));
 				CursorPageResponse<MobileDataSummary> response = CursorPageResponse.of(summaries,
 						CursorPageResponse.PageInfo.of(2L, false, 2));
 
 				given(productRepository.findMobileDataByCursor(null, 3,
-						ProductSortOption.AMOUNT_ASC, 5.0F)).willReturn(response);
+						ProductSortOption.AMOUNT_ASC, new BigDecimal("5.0"))).willReturn(response);
 
 				// when
 				CursorPageResponse<MobileDataSummary> result = productService.findMobileDataByCursor(
-						null, 3, "AMOUNT_ASC", 5.0F);
+						null, 3, "AMOUNT_ASC", new BigDecimal("5.0"));
 
 				// then
 				assertThat(result.getData()).hasSize(2);
-				assertThat(result.getData().get(0).getRemainAmount()).isGreaterThanOrEqualTo(5);
+				assertThat(Optional.of(
+						result.getData().get(0).getRemainAmount())).isEqualTo(5);
 			}
 		}
 
@@ -667,9 +675,9 @@ class ProductServiceTest {
 				assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);
 				assertThat(product.getPrice()).isEqualTo(NEW_PRICE_9000);
 				assertThat(mobileData.getDataAmount()).isEqualTo(
-						BEFORE_DATA_AMOUNT + CHANGED_AMOUNT);
+						BEFORE_DATA_AMOUNT.add(CHANGED_AMOUNT));
 				assertThat(mobileData.getRemainAmount()).isEqualTo(
-						BEFORE_REMAIN_AMOUNT + CHANGED_AMOUNT);
+						BEFORE_REMAIN_AMOUNT.add(CHANGED_AMOUNT));
 			}
 		}
 

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -190,13 +190,16 @@ class TradeControllerTest {
 				Member afterSeller = memberRepository.findById(seller.getId()).orElseThrow();
 
 				assertThat(soldOutProduct.getState()).isEqualTo(ProductState.SOLD_OUT);
-				assertThat(soldOutMobileData.getRemainAmount()).isEqualTo(0);
-				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(soldOutMobileData.getRemainAmount()).isEqualByComparingTo(
+						BigDecimal.ZERO);
+				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.add(mobileData.getDataAmount()));
-				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.subtract(mobileData.getDataAmount()));
-				assertThat(afterBuyer.getBuyingData()).isEqualTo(mobileData.getDataAmount());
-				assertThat(afterSeller.getSellingData()).isEqualTo(mobileData.getDataAmount());
+				assertThat(afterBuyer.getBuyingData()).isEqualByComparingTo(
+						mobileData.getDataAmount());
+				assertThat(afterSeller.getSellingData()).isEqualByComparingTo(
+						mobileData.getDataAmount());
 			}
 
 			@Test
@@ -262,14 +265,14 @@ class TradeControllerTest {
 				Member afterSeller = memberRepository.findById(seller.getId()).orElseThrow();
 
 				assertThat(soldOutProduct.getState()).isEqualTo(ProductState.ACTIVE);
-				assertThat(soldOutMobileData.getRemainAmount()).isEqualTo(
+				assertThat(soldOutMobileData.getRemainAmount()).isEqualByComparingTo(
 						DATA_AMOUNT_2.subtract(DATA_AMOUNT_1));
-				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
-				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.subtract(DATA_AMOUNT_1));
-				assertThat(afterBuyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
-				assertThat(afterSeller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
+				assertThat(afterBuyer.getBuyingData()).isEqualByComparingTo(DATA_AMOUNT_1);
+				assertThat(afterSeller.getSellingData()).isEqualByComparingTo(DATA_AMOUNT_1);
 			}
 		}
 
@@ -568,7 +571,7 @@ class TradeControllerTest {
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
 						dataAmount);
 
-				assertThat(response.getTotalAmount()).isEqualTo(DATA_AMOUNT_2);
+				assertThat(response.getTotalAmount()).isEqualByComparingTo(DATA_AMOUNT_2);
 				assertThat(response.getTotalPrice()).isEqualTo(
 						PRICE_1500 + PRICE_3000); // 조합된 상품의 총 가격
 				assertThat(response.getCombinations().size()).isEqualTo(2); // 조합된 상품 개수 확인
@@ -579,14 +582,16 @@ class TradeControllerTest {
 				assertThat(result1.getProductId()).isEqualTo(product1.getId());
 				assertThat(result1.getMobileDataId()).isEqualTo(mobileData1.getId());
 				assertThat(result1.getPrice()).isEqualTo(product1.getPrice());
-				assertThat(result1.getRemainAmount()).isEqualTo(mobileData1.getRemainAmount());
+				assertThat(result1.getRemainAmount()).isEqualByComparingTo(
+						mobileData1.getRemainAmount());
 				assertThat(result1.getPricePer100MB()).isEqualTo(mobileData1.getPricePer100MB());
 				assertThat(result1.isSplitType()).isEqualTo(mobileData1.isSplitType());
 
 				assertThat(result2.getProductId()).isEqualTo(product2.getId());
 				assertThat(result2.getMobileDataId()).isEqualTo(mobileData2.getId());
 				assertThat(result2.getPrice()).isEqualTo(product2.getPrice());
-				assertThat(result2.getRemainAmount()).isEqualTo(mobileData2.getRemainAmount());
+				assertThat(result2.getRemainAmount()).isEqualByComparingTo(
+						mobileData2.getRemainAmount());
 				assertThat(result2.getPricePer100MB()).isEqualTo(mobileData2.getPricePer100MB());
 				assertThat(result2.isSplitType()).isEqualTo(mobileData2.isSplitType());
 			}
@@ -625,7 +630,7 @@ class TradeControllerTest {
 				FindMobileDataScrapResponse response = tradeService.findMobileDataScrap(
 						dataAmount);
 
-				assertThat(response.getTotalAmount()).isEqualTo(0);
+				assertThat(response.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
 				assertThat(response.getTotalPrice()).isEqualTo(0); // 조합된 상품의 총 가격
 				assertThat(response.getCombinations().size()).isEqualTo(0); // 조합된 상품 개수 확인
 			}
@@ -740,16 +745,19 @@ class TradeControllerTest {
 				MobileData updatedMobileData2 = mobileDataRepository.findById(mobileData2.getId())
 						.orElseThrow();
 
-				assertThat(updatedMobileData1.getRemainAmount()).isEqualTo(0);
-				assertThat(updatedMobileData2.getRemainAmount()).isEqualTo(0);
+				assertThat(updatedMobileData1.getRemainAmount()).isEqualByComparingTo(
+						BigDecimal.ZERO);
+				assertThat(updatedMobileData2.getRemainAmount()).isEqualByComparingTo(
+						BigDecimal.ZERO);
 
 				assertThat(updatedBuyer.getCash()).isEqualTo(CASH_5000 - request.totalPrice());
-				assertThat(updatedBuyer.getBuyingData()).isEqualTo(request.totalAmount());
+				assertThat(updatedBuyer.getBuyingData()).isEqualByComparingTo(
+						request.totalAmount());
 
-				assertThat(updatedSeller1.getSellingData()).isEqualTo(DATA_AMOUNT_1);
+				assertThat(updatedSeller1.getSellingData()).isEqualByComparingTo(DATA_AMOUNT_1);
 				assertThat(updatedSeller1.getCash()).isEqualTo(PRICE_1500);
 
-				assertThat(updatedSeller2.getSellingData()).isEqualTo(DATA_AMOUNT_1);
+				assertThat(updatedSeller2.getSellingData()).isEqualByComparingTo(DATA_AMOUNT_1);
 				assertThat(updatedSeller2.getCash()).isEqualTo(PRICE_3000);
 			}
 		}

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -2,32 +2,17 @@ package com.dapanda.trade.controller;
 
 
 import static com.dapanda.TestConstants.Member.CASH_5000;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_2;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_150;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_300;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_2;
+import static com.dapanda.TestConstants.MobileData.*;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Plan.PROVIDING_DATA_AMOUNT_10;
-import static com.dapanda.TestConstants.Product.PRICE_1500;
-import static com.dapanda.TestConstants.Product.PRICE_3000;
-import static com.dapanda.TestConstants.Product.PRICE_500;
-import static com.dapanda.TestConstants.Wifi.ADDRESS;
-import static com.dapanda.TestConstants.Wifi.CONTENT;
-import static com.dapanda.TestConstants.Wifi.END_TIME;
-import static com.dapanda.TestConstants.Wifi.LATITUDE;
-import static com.dapanda.TestConstants.Wifi.LONGITUDE;
-import static com.dapanda.TestConstants.Wifi.START_TIME;
-import static com.dapanda.TestConstants.Wifi.TITLE;
+import static com.dapanda.TestConstants.Product.*;
+import static com.dapanda.TestConstants.Wifi.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -45,39 +30,22 @@ import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.entity.PlanFixture;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.ItemType;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.MobileDataFixture;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductFixture;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.entity.WifiFixture;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
 import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
+import com.dapanda.trade.dto.request.*;
 import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.entity.Trade;
-import com.dapanda.trade.entity.TradeDetails;
-import com.dapanda.trade.entity.TradeFixture;
+import com.dapanda.trade.entity.*;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
 import com.dapanda.trade.service.TradeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import java.util.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -224,9 +192,9 @@ class TradeControllerTest {
 				assertThat(soldOutProduct.getState()).isEqualTo(ProductState.SOLD_OUT);
 				assertThat(soldOutMobileData.getRemainAmount()).isEqualTo(0);
 				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 + mobileData.getDataAmount());
+						PROVIDING_DATA_AMOUNT_10.add(mobileData.getDataAmount()));
 				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 - mobileData.getDataAmount());
+						PROVIDING_DATA_AMOUNT_10.subtract(mobileData.getDataAmount()));
 				assertThat(afterBuyer.getBuyingData()).isEqualTo(mobileData.getDataAmount());
 				assertThat(afterSeller.getSellingData()).isEqualTo(mobileData.getDataAmount());
 			}
@@ -295,11 +263,11 @@ class TradeControllerTest {
 
 				assertThat(soldOutProduct.getState()).isEqualTo(ProductState.ACTIVE);
 				assertThat(soldOutMobileData.getRemainAmount()).isEqualTo(
-						DATA_AMOUNT_2 - DATA_AMOUNT_1);
+						DATA_AMOUNT_2.subtract(DATA_AMOUNT_1));
 				assertThat(afterBuyerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 + DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
 				assertThat(afterSellerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 - DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.subtract(DATA_AMOUNT_1));
 				assertThat(afterBuyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
 				assertThat(afterSeller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
 			}
@@ -546,7 +514,7 @@ class TradeControllerTest {
 				List<Product> products = Arrays.asList(product1, product2);
 				productRepository.saveAll(products);
 
-				float dataAmount = DATA_AMOUNT_2;
+				BigDecimal dataAmount = DATA_AMOUNT_2;
 
 				// when & then
 				mockMvc.perform(get("/api/trades/mobile-data/scrap")
@@ -628,7 +596,7 @@ class TradeControllerTest {
 			void findDataProductScrapWhenNotExist() throws Exception {
 
 				// given
-				float dataAmount = DATA_AMOUNT_2;
+				BigDecimal dataAmount = DATA_AMOUNT_2;
 
 				// when & then
 				mockMvc.perform(get("/api/trades/mobile-data/scrap")
@@ -893,9 +861,9 @@ class TradeControllerTest {
 				memberRepository.saveAll(members);
 
 				MobileData mobileData1 = MobileDataFixture.createMobileData(DATA_AMOUNT_1,
-						0, PRICE_PER_100MB_150);
+						BigDecimal.ZERO, PRICE_PER_100MB_150);
 				MobileData mobileData2 = MobileDataFixture.createMobileDataSplitType(DATA_AMOUNT_2,
-						0, PRICE_PER_100MB_300);
+						BigDecimal.ZERO, PRICE_PER_100MB_300);
 				List<MobileData> mobileDataList = Arrays.asList(mobileData1, mobileData2);
 				mobileDataRepository.saveAll(mobileDataList);
 

--- a/src/test/java/com/dapanda/trade/entity/TradeFixture.java
+++ b/src/test/java/com/dapanda/trade/entity/TradeFixture.java
@@ -4,6 +4,7 @@ import com.dapanda.member.entity.Member;
 import com.dapanda.product.entity.MobileData;
 import com.dapanda.product.entity.Product;
 import com.dapanda.trade.dto.MobileDataScrap;
+import java.math.BigDecimal;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class TradeFixture {
@@ -11,7 +12,7 @@ public class TradeFixture {
 	public static Trade createTradeMobileDataDefault(Member member) {
 
 		return Trade.of(
-				0.5F,
+				BigDecimal.valueOf(0.5),
 				1000,
 				TradeType.MOBILE_PURCHASE_SINGLE,
 				member
@@ -28,7 +29,7 @@ public class TradeFixture {
 	}
 
 	public static MobileDataScrap createMobileDataScrap(Product product, MobileData mobileData,
-			int purchasePrice, float purchaseDataAmount) {
+			int purchasePrice, BigDecimal purchaseDataAmount) {
 
 		return new MobileDataScrap(product.getId(), mobileData.getId(),
 				product.getMember().getName(), product.getPrice(), purchasePrice,

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -110,14 +110,19 @@ class TradeServiceTest {
 				tradeService.defaultPurchaseMobileData(BUYER_MEMBER_ID, request);
 
 				// then
+				Plan updateBuyerPlan = planRepository.findByMember(buyer).orElseThrow();
+				Plan updateSellerPlan = planRepository.findByMember(seller).orElseThrow();
+
 				assertThat(product.getState()).isEqualTo(ProductState.SOLD_OUT);
-				assertThat(mobileData.getRemainAmount()).isEqualTo(0);
-				assertThat(buyerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(mobileData.getRemainAmount()).isEqualByComparingTo(
+						BigDecimal.valueOf(0));
+				assertThat(updateBuyerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
-				assertThat(sellerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
-				assertThat(buyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
-				assertThat(seller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
+				assertThat(updateSellerPlan.getProvidingDataAmount()).isEqualByComparingTo(
+						PROVIDING_DATA_AMOUNT_10.subtract(DATA_AMOUNT_1));
+				assertThat(buyer.getBuyingData()).isEqualByComparingTo(DATA_AMOUNT_1);
+				assertThat(seller.getSellingData()).isEqualByComparingTo(DATA_AMOUNT_1);
+
 			}
 
 			@Test
@@ -157,14 +162,14 @@ class TradeServiceTest {
 
 				// then
 				assertThat(product.getState()).isEqualTo(ProductState.ACTIVE);
-				assertThat(mobileData.getRemainAmount()).isEqualTo(
+				assertThat(mobileData.getRemainAmount()).isEqualByComparingTo(
 						DATA_AMOUNT_2.subtract(DATA_AMOUNT_1));
-				assertThat(buyerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(buyerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
-				assertThat(sellerPlan.getProvidingDataAmount()).isEqualTo(
+				assertThat(sellerPlan.getProvidingDataAmount()).isEqualByComparingTo(
 						PROVIDING_DATA_AMOUNT_10.subtract(DATA_AMOUNT_1));
-				assertThat(buyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
-				assertThat(seller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
+				assertThat(buyer.getBuyingData()).isEqualByComparingTo(DATA_AMOUNT_1);
+				assertThat(seller.getSellingData()).isEqualByComparingTo(DATA_AMOUNT_1);
 			}
 		}
 
@@ -375,7 +380,7 @@ class TradeServiceTest {
 						dataAmount);
 
 				// then
-				assertThat(response.getTotalAmount()).isEqualTo(0);
+				assertThat(response.getTotalAmount()).isEqualTo(BigDecimal.ZERO);
 				assertThat(response.getTotalPrice()).isEqualTo(0); // 조합된 상품의 총 가격
 				assertThat(response.getCombinations().size()).isEqualTo(0); // 조합된 상품 개수 확인
 			}
@@ -441,8 +446,8 @@ class TradeServiceTest {
 				tradeService.scrapPurchaseMobileData(BUYER_MEMBER_ID, request);
 
 				// then
-				assertThat(mobileData1.getRemainAmount()).isEqualTo(0);
-				assertThat(mobileData2.getRemainAmount()).isEqualTo(0);
+				assertThat(mobileData1.getRemainAmount()).isEqualTo(BigDecimal.valueOf(0.0));
+				assertThat(mobileData2.getRemainAmount()).isEqualTo(BigDecimal.valueOf(0.0));
 
 				assertThat(buyer.getCash()).isEqualTo(CASH_5000 - request.totalPrice());
 				assertThat(buyer.getBuyingData()).isEqualTo(request.totalAmount());

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -1,34 +1,14 @@
 package com.dapanda.trade.service;
 
-import static com.dapanda.TestConstants.Member.BUYER_MEMBER_ID;
-import static com.dapanda.TestConstants.Member.CASH_3000;
-import static com.dapanda.TestConstants.Member.CASH_5000;
-import static com.dapanda.TestConstants.Member.MEMBER_ID;
-import static com.dapanda.TestConstants.Member.SELLER_MEMBER_ID;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.DATA_AMOUNT_2;
-import static com.dapanda.TestConstants.MobileData.MOBILE_DATA_ID;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_150;
-import static com.dapanda.TestConstants.MobileData.PRICE_PER_100MB_300;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_1;
-import static com.dapanda.TestConstants.MobileData.REMAIN_AMOUNT_2;
+import static com.dapanda.TestConstants.Member.*;
+import static com.dapanda.TestConstants.MobileData.*;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_CURSOR_ID;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Plan.PROVIDING_DATA_AMOUNT_10;
-import static com.dapanda.TestConstants.Product.PRICE_1500;
-import static com.dapanda.TestConstants.Product.PRICE_3000;
-import static com.dapanda.TestConstants.Product.PRICE_500;
-import static com.dapanda.TestConstants.Product.PRODUCT_ID;
+import static com.dapanda.TestConstants.Product.*;
 import static com.dapanda.TestConstants.Trade.TRADE_ID_1;
 import static com.dapanda.TestConstants.Trade.TRADE_ID_2;
-import static com.dapanda.TestConstants.Wifi.ADDRESS;
-import static com.dapanda.TestConstants.Wifi.CONTENT;
-import static com.dapanda.TestConstants.Wifi.END_TIME;
-import static com.dapanda.TestConstants.Wifi.LATITUDE;
-import static com.dapanda.TestConstants.Wifi.LONGITUDE;
-import static com.dapanda.TestConstants.Wifi.START_TIME;
-import static com.dapanda.TestConstants.Wifi.TITLE;
-import static com.dapanda.TestConstants.Wifi.WIFI_ID;
+import static com.dapanda.TestConstants.Wifi.*;
 import static com.dapanda.trade.entity.TradeType.WIFI;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -44,39 +24,20 @@ import com.dapanda.member.repository.MemberRepository;
 import com.dapanda.plan.entity.Plan;
 import com.dapanda.plan.entity.PlanFixture;
 import com.dapanda.plan.repository.PlanRepository;
-import com.dapanda.product.entity.MobileData;
-import com.dapanda.product.entity.MobileDataFixture;
-import com.dapanda.product.entity.Product;
-import com.dapanda.product.entity.ProductFixture;
-import com.dapanda.product.entity.ProductState;
-import com.dapanda.product.entity.Wifi;
-import com.dapanda.product.entity.WifiFixture;
-import com.dapanda.product.repository.MobileDataRepository;
-import com.dapanda.product.repository.ProductRepository;
-import com.dapanda.product.repository.WifiRepository;
-import com.dapanda.trade.dto.CashHistoryMonthlySummary;
-import com.dapanda.trade.dto.CashHistorySummary;
-import com.dapanda.trade.dto.MobileDataScrap;
-import com.dapanda.trade.dto.PurchaseHistorySummary;
-import com.dapanda.trade.dto.request.DefaultPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.request.PurchaseWifiRequest;
-import com.dapanda.trade.dto.request.ScrapPurchaseMobileDataRequest;
-import com.dapanda.trade.dto.response.FindCashHistoryResponse;
-import com.dapanda.trade.dto.response.FindMobileDataScrapResponse;
-import com.dapanda.trade.dto.response.FindTradeHistoryResponse;
+import com.dapanda.product.entity.*;
+import com.dapanda.product.repository.*;
+import com.dapanda.trade.dto.*;
+import com.dapanda.trade.dto.request.*;
+import com.dapanda.trade.dto.response.*;
 import com.dapanda.trade.entity.Trade;
 import com.dapanda.trade.entity.TradeFixture;
 import com.dapanda.trade.repository.TradeDetailsRepository;
 import com.dapanda.trade.repository.TradeRepository;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import java.util.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -152,9 +113,9 @@ class TradeServiceTest {
 				assertThat(product.getState()).isEqualTo(ProductState.SOLD_OUT);
 				assertThat(mobileData.getRemainAmount()).isEqualTo(0);
 				assertThat(buyerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 + DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
 				assertThat(sellerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 - DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
 				assertThat(buyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
 				assertThat(seller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
 			}
@@ -196,11 +157,12 @@ class TradeServiceTest {
 
 				// then
 				assertThat(product.getState()).isEqualTo(ProductState.ACTIVE);
-				assertThat(mobileData.getRemainAmount()).isEqualTo(DATA_AMOUNT_2 - DATA_AMOUNT_1);
+				assertThat(mobileData.getRemainAmount()).isEqualTo(
+						DATA_AMOUNT_2.subtract(DATA_AMOUNT_1));
 				assertThat(buyerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 + DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.add(DATA_AMOUNT_1));
 				assertThat(sellerPlan.getProvidingDataAmount()).isEqualTo(
-						PROVIDING_DATA_AMOUNT_10 - DATA_AMOUNT_1);
+						PROVIDING_DATA_AMOUNT_10.subtract(DATA_AMOUNT_1));
 				assertThat(buyer.getBuyingData()).isEqualTo(DATA_AMOUNT_1);
 				assertThat(seller.getSellingData()).isEqualTo(DATA_AMOUNT_1);
 			}
@@ -362,7 +324,7 @@ class TradeServiceTest {
 				MobileDataScrap mobileDataScrap2 = TradeFixture.createMobileDataScrap(product2,
 						mobileData2, PRICE_3000, DATA_AMOUNT_1);
 
-				float dataAmount = DATA_AMOUNT_2;
+				BigDecimal dataAmount = DATA_AMOUNT_2;
 
 				given(productRepository.findMobileDataScrap(dataAmount)).willReturn(new ArrayList<>(
 						List.of(mobileDataScrap1, mobileDataScrap2)));
@@ -403,7 +365,7 @@ class TradeServiceTest {
 				Member buyer = MemberFixture.createMember1WithId(BUYER_MEMBER_ID);
 				ReflectionTestUtils.setField(buyer, "cash", CASH_5000);
 
-				float dataAmount = DATA_AMOUNT_2;
+				BigDecimal dataAmount = DATA_AMOUNT_2;
 
 				given(productRepository.findMobileDataScrap(dataAmount)).willReturn(
 						new ArrayList<>());
@@ -549,7 +511,7 @@ class TradeServiceTest {
 				ReflectionTestUtils.setField(buyer, "cash", CASH_5000);
 
 				MobileData mobileData1 = MobileDataFixture.createMobileDataWithId(MOBILE_DATA_ID,
-						DATA_AMOUNT_1, 0, PRICE_PER_100MB_150);
+						DATA_AMOUNT_1, BigDecimal.ZERO, PRICE_PER_100MB_150);
 				MobileData mobileData2 = MobileDataFixture.createMobileDataSplitTypeWithId(
 						MOBILE_DATA_ID + 1, DATA_AMOUNT_2, REMAIN_AMOUNT_1, PRICE_PER_100MB_300);
 				Product product1 = ProductFixture.createMobileDataProductWithId(
@@ -720,7 +682,7 @@ class TradeServiceTest {
 
 						TRADE_ID_1,
 						WIFI,
-						0f,
+						BigDecimal.valueOf(0),
 						TITLE,
 						trade1.getCreatedAt()
 				);
@@ -729,7 +691,7 @@ class TradeServiceTest {
 
 						TRADE_ID_2,
 						WIFI,
-						0f,
+						BigDecimal.valueOf(0),
 						TITLE + 1,
 						trade2.getCreatedAt()
 				);


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 단위를 `float`에서 `BigDecimal`로 수정
- 데이터 상품 일반 조회시 상품 아이디 필드를 id에서 productId로 변경

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 데이터 단위를 float → BigDecimal로 수정한 이유는 부동소수점 연산 오차로 인한 데이터 조회 오류 때문입니다!
BigDecimal은 정밀한 소수 연산이 가능하여 특히 금액/데이터 용량 계산에 안정적이라 판단했습니다.
이번 경험을 통해 실제 서비스 로직에서 float 연산 오차가 실질적인 장애로 이어질 수 있음을 체감했고, 앞으로는 이런 부분도 꼼꼼히 신경쓰며 설계하겠습니다!
- commit 메시지에 이슈번호를 잘못 적었습니다..! 앞으로 주의하겠습니다,,

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #162 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?