### PR TITLE
[DP-179] fix: 데이터 상품 수정 시 데이터양 계산 방식 수정

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -1025,6 +1025,10 @@ include::{snippets}/product/get-wifi-info-invalid-product-error/http-response.ad
 
 include::{snippets}/product/put-mobile-data/http-request.adoc[]
 
+===== 요청 필드
+
+include::{snippets}/product/put-mobile-data/request-fields.adoc[]
+
 ===== 응답
 
 include::{snippets}/product/put-mobile-data/http-response.adoc[]

--- a/src/main/java/com/dapanda/product/entity/MobileData.java
+++ b/src/main/java/com/dapanda/product/entity/MobileData.java
@@ -49,7 +49,7 @@ public class MobileData {
 
 	public void updateMobileData(BigDecimal changedAmount, int pricePer100MB, boolean isSplitType) {
 
-		this.dataAmount = this.dataAmount.add(changedAmount);
+		this.dataAmount = changedAmount;
 		this.remainAmount = changedAmount;
 		this.pricePer100MB = pricePer100MB;
 		this.isSplitType = isSplitType;

--- a/src/main/java/com/dapanda/product/entity/MobileData.java
+++ b/src/main/java/com/dapanda/product/entity/MobileData.java
@@ -50,7 +50,7 @@ public class MobileData {
 	public void updateMobileData(BigDecimal changedAmount, int pricePer100MB, boolean isSplitType) {
 
 		this.dataAmount = this.dataAmount.add(changedAmount);
-		this.remainAmount = this.remainAmount.add(changedAmount);
+		this.remainAmount = changedAmount;
 		this.pricePer100MB = pricePer100MB;
 		this.isSplitType = isSplitType;
 	}

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -282,7 +282,6 @@ public class ProductService {
 			throw new GlobalException(ResultCode.INVALID_DATA_TRANSFER_AMOUNT);
 		}
 
-		System.out.println("member.getSellingData() = " + member.getSellingData());
 		if (member.getSellingData().add(changedDataAmount)
 				.compareTo(BigDecimal.valueOf(MobileData.MAX_TRANSFERABLE_DATA_AMOUNT)) > 0) {
 			throw new GlobalException(ResultCode.EXCEEDED_TRANSFER_LIMIT);

--- a/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
@@ -99,13 +99,10 @@ class PaymentControllerTest {
 
 		// MySQL 초기화
 		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
-		jdbcTemplate.execute("TRUNCATE TABLE review");
 		jdbcTemplate.execute("TRUNCATE TABLE member");
 		jdbcTemplate.execute("TRUNCATE TABLE trade");
 		jdbcTemplate.execute("TRUNCATE TABLE product");
-		jdbcTemplate.execute("TRUNCATE TABLE trade_details");
 		jdbcTemplate.execute("TRUNCATE TABLE payment");
-		jdbcTemplate.execute("TRUNCATE TABLE report");
 		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
 
 		// Redis 초기화

--- a/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
@@ -422,7 +422,8 @@ class PaymentControllerTest {
 						.andDo(print())
 						.andDo(document("payments/refund-cash",
 								requestFields(
-										fieldWithPath("requestId").description("환불 요청 아이디 (임의의 아이디 생성)"),
+										fieldWithPath("requestId").description(
+												"환불 요청 아이디 (임의의 아이디 생성)"),
 										fieldWithPath("refundAmount").description("환불 금액")
 								),
 								responseFields(
@@ -576,7 +577,6 @@ class PaymentControllerTest {
 //						try {
 //							Thread.sleep(40000000); // 오래 점유하여 다른 스레드 타임아웃 유도
 //						} catch (InterruptedException e) {
-//							System.out.println("e = " + e);
 //							throw new RuntimeException(e);
 //						}
 //					});

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -966,7 +966,7 @@ class ProductControllerTest {
 										fieldWithPath("productId").description("상품 아이디 (필수)"),
 										fieldWithPath("price").description("상품 가격 (필수)"),
 										fieldWithPath("changedAmount").description(
-												"데이터 변화량 (필수, 음수/양수)"),
+												"상품 데이터양 (필수)"),
 										fieldWithPath("isSplitType").description("분할 여부 (필수)")
 								),
 								responseFields(

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -982,10 +982,9 @@ class ProductControllerTest {
 
 				assertThat(updatedProduct.getId()).isEqualTo(product.getId());
 				assertThat(updatedProduct.getPrice()).isEqualTo(NEW_PRICE_9000);
-				assertThat(updatedMobileData.getDataAmount()).isEqualByComparingTo(
-						BEFORE_DATA_AMOUNT.add(CHANGED_AMOUNT));
+				assertThat(updatedMobileData.getDataAmount()).isEqualByComparingTo(CHANGED_AMOUNT);
 				assertThat(updatedMobileData.getRemainAmount()).isEqualByComparingTo(
-						BEFORE_REMAIN_AMOUNT.add(CHANGED_AMOUNT));
+						CHANGED_AMOUNT);
 			}
 		}
 

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -1,8 +1,8 @@
 package com.dapanda.product.service;
 
 import static com.dapanda.TestConstants.Member.*;
-import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.MobileData.*;
+import static com.dapanda.TestConstants.MobileData.SELLING_DATA;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_CURSOR_ID;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static com.dapanda.TestConstants.Product.*;
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.dapanda.common.dto.response.CountCursorPageResponse;
 import com.dapanda.common.dto.response.CursorPageResponse;
@@ -610,8 +612,7 @@ class ProductServiceTest {
 
 				// given
 				UpdateMobileDataRequest request = new UpdateMobileDataRequest(PRODUCT_ID,
-						NEW_PRICE_9000,
-						CHANGED_AMOUNT, SPLIT_TYPE);
+						NEW_PRICE_9000, CHANGED_AMOUNT, SPLIT_TYPE);
 
 				Member member = MemberFixture.createMember1WithId(MEMBER_ID);
 				MobileData mobileData = MobileDataFixture.createMobileData(BEFORE_DATA_AMOUNT,
@@ -619,22 +620,25 @@ class ProductServiceTest {
 				Product product = ProductFixture.createMobileDataProductWithId(PRODUCT_ID,
 						mobileData.getId(), PRICE_3000, member);
 
+				MobileData mockMobileData = spy(mobileData); // 실제 객체 mocking
+
 				given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(member));
 				given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
 				given(mobileDataRepository.findById(mobileData.getId())).willReturn(
-						Optional.of(mobileData));
+						Optional.of(mockMobileData));
 
 				// when
 				UpdateMobileDataResponse response = productService.updateMobileData(request,
 						MEMBER_ID);
 
 				// then
+				int expected100MBPerPrice = (int) Math.ceil(
+						NEW_PRICE_9000 / (CHANGED_AMOUNT.floatValue() * 10));
+
 				assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);
-				assertThat(product.getPrice()).isEqualTo(NEW_PRICE_9000);
-				assertThat(mobileData.getDataAmount()).isEqualTo(
-						BEFORE_DATA_AMOUNT.add(CHANGED_AMOUNT));
-				assertThat(mobileData.getRemainAmount()).isEqualTo(
-						BEFORE_REMAIN_AMOUNT.add(CHANGED_AMOUNT));
+
+				verify(mockMobileData).updateMobileData(CHANGED_AMOUNT, expected100MBPerPrice,
+						SPLIT_TYPE);
 			}
 		}
 
@@ -648,8 +652,7 @@ class ProductServiceTest {
 
 				// given
 				UpdateMobileDataRequest request = new UpdateMobileDataRequest(PRODUCT_ID,
-						NEW_PRICE_9000,
-						CHANGED_AMOUNT, SPLIT_TYPE);
+						NEW_PRICE_9000, CHANGED_AMOUNT, SPLIT_TYPE);
 
 				Member member = MemberFixture.createMember1WithId(MEMBER_ID);
 				MobileData mobileData = MobileDataFixture.createMobileData(BEFORE_DATA_AMOUNT,

--- a/src/test/java/com/dapanda/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/dapanda/review/service/ReviewServiceTest.java
@@ -1,33 +1,5 @@
 package com.dapanda.review.service;
 
-import com.dapanda.common.dto.response.CursorPageResponse;
-import com.dapanda.common.exception.GlobalException;
-import com.dapanda.common.exception.ResultCode;
-import com.dapanda.member.entity.Member;
-import com.dapanda.member.entity.MemberFixture;
-import com.dapanda.member.repository.MemberRepository;
-import com.dapanda.review.dto.request.CreateReviewRequest;
-import com.dapanda.review.dto.request.ReadReviewRequest;
-import com.dapanda.review.dto.request.UpdateReviewRequest;
-import com.dapanda.review.dto.response.*;
-import com.dapanda.review.entity.Review;
-import com.dapanda.review.entity.ReviewFixture;
-import com.dapanda.review.repository.ReviewRepository;
-import com.dapanda.trade.entity.Trade;
-import com.dapanda.trade.entity.TradeFixture;
-import com.dapanda.trade.repository.TradeRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import static com.dapanda.TestConstants.Member.*;
 import static com.dapanda.TestConstants.Pagination.*;
 import static com.dapanda.TestConstants.Review.*;
@@ -38,6 +10,27 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+
+import com.dapanda.common.dto.response.CursorPageResponse;
+import com.dapanda.common.exception.GlobalException;
+import com.dapanda.common.exception.ResultCode;
+import com.dapanda.member.entity.Member;
+import com.dapanda.member.entity.MemberFixture;
+import com.dapanda.member.repository.MemberRepository;
+import com.dapanda.review.dto.request.*;
+import com.dapanda.review.dto.response.*;
+import com.dapanda.review.entity.Review;
+import com.dapanda.review.entity.ReviewFixture;
+import com.dapanda.review.repository.ReviewRepository;
+import com.dapanda.trade.entity.Trade;
+import com.dapanda.trade.entity.TradeFixture;
+import com.dapanda.trade.repository.TradeRepository;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("리뷰 서비스 테스트")
@@ -336,7 +329,6 @@ class ReviewServiceTest {
 				Trade trade = TradeFixture.createTrade1WithId(member, TRADE_ID_2);
 				Review review = ReviewFixture.createReviewWithRating(trade, REVIEW_ID,
 						oldRating);
-				System.out.println(member == review.getTrade().getMember());
 				UpdateReviewRequest request = new UpdateReviewRequest(newRating, COMMENT);
 
 				given(reviewRepository.findById(REVIEW_ID)).willReturn(Optional.of(review));


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 상품 수정 시 데이터량(`changedAmount`) 기반의 가격 계산 로직 개선
- 서비스 단위 테스트에 `spy()`와 `verify()`를 활용하여 `MobileData.updateMobileData()` 메서드의 호출 여부를 검증하도록 테스트 코드 보완

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 서비스 계층 단위 테스트에서는 DB에 저장되지 않는 Entity의 상태 변화나 메서드 호출 여부를 `verify()`로 검증할 수 있다는 점에서 `spy()`의 유용함을 체감했습니다. 앞으로 다른 도메인 단위 테스트에서도 spy()를 적절히 활용해보려 합니다!

```java
// given
Member member = MemberFixture.createMember1WithId(MEMBER_ID);
MobileData mockMobileData = spy(mobileData); // 실제 객체를 감싸는 스파이 생성
				
(생략)

// when
UpdateMobileDataResponse response = productService.updateMobileData(request, MEMBER_ID);

// then
int expected100MBPerPrice = (int) Math.ceil(NEW_PRICE_9000 / (CHANGED_AMOUNT.floatValue() * 10));

assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);

verify(mockMobileData).updateMobileData(CHANGED_AMOUNT, expected100MBPerPrice, SPLIT_TYPE);
```

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #178

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?