### PR TITLE
[DP-182] fix: 헬스체크가 애플리케이션 실행보다 빠른 경우를 대비하여 대기시간 추가

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,6 +12,23 @@ sudo chown ubuntu:ubuntu "$LOG_DIR"
 # 앱 실행
 echo "Starting $APP_NAME with prod profile..."
 nohup java -jar "$APP_DIR/$APP_NAME" --spring.profiles.active=prod > "$LOG_FILE" 2>&1 &
+# === 앱 Health Check 대기 ===
+echo "Waiting for application health check to pass..."
+
+for i in {1..30}; do
+  sleep 2
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health)
+  echo "  [$i] Health check status: $STATUS"
+  if [ "$STATUS" -eq 200 ]; then
+    echo "✅ Application is healthy."
+    break
+  fi
+done
+
+if [ "$STATUS" -ne 200 ]; then
+  echo "❌ Application health check failed. Exiting..."
+  exit 1
+fi
 # ===== CloudWatch Agent 설치 여부 확인 후 설치 =====
 echo "Checking CloudWatch Agent installation..."
 if ! command -v "$CLOUDWATCH_AGENT_BIN" &> /dev/null; then


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 배포 시 헬스체크가 실패하는 문제를 확인하였고, 애플리케이션 실행보다 헬스체크가 빨라서 발생한다고 판단하여 대기시간을 주도록 start.sh를 수정하였습니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #183 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?