### PR TITLE
[DP-181] fix: 데이터 상품 조회 시 정렬 오류 수정

### DIFF
--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import static com.dapanda.product.entity.QMobileData.mobileData;
 import static com.dapanda.product.entity.QProduct.product;
 import static com.dapanda.product.entity.QProductImage.productImage;
 import static com.dapanda.product.entity.QWifi.wifi;
-import static com.dapanda.review.entity.QReview.review;
 
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.dto.MobileDataSummary;
@@ -60,7 +59,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.from(product)
 				.join(mobileData).on(mobileData.id.eq(product.itemId))
 				.where(isActiveProduct(),
-						gtCursorId(cursorId),
+						productSortOption == ProductSortOption.RECENT ? ltCursorId(cursorId)
+								: gtCursorId(cursorId),
 						eqDataAmount(dataAmount)
 				)
 				.orderBy(
@@ -123,10 +123,6 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.groupBy(product.id)
 				.join(wifi).on(wifi.id.eq(product.itemId))
 				.leftJoin(member).on(product.member.id.eq(member.id))
-				.where(
-						gtCursorId(cursorId),
-						isOpenNow(isOpen, now)
-				)
 				.leftJoin(productImage).on(
 						productImage.wifiId.eq(wifi.id)
 								.and(productImage.priority.eq(
@@ -375,6 +371,11 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 	private BooleanExpression gtCursorId(Long cursorId) {
 
 		return cursorId != null ? product.id.gt(cursorId) : null;
+	}
+
+	private BooleanExpression ltCursorId(Long cursorId) {
+
+		return cursorId != null ? product.id.lt(cursorId) : null;
 	}
 
 	private BooleanExpression eqDataAmount(BigDecimal dataAmount) {

--- a/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/dapanda/product/controller/ProductControllerTest.java
@@ -369,14 +369,11 @@ class ProductControllerTest {
 				Product product3 = ProductFixture.createMobileDataProduct(5000,
 						mobileData3.getId(), member);
 				productRepository.saveAll(List.of(product1, product2, product3));
-				MobileDataCursorRequest request = new MobileDataCursorRequest(null, size,
-						productSortOption, dataAmount);
 
 				// when & then
 				mockMvc.perform(
 								MockMvcRequestBuilders.get(
 												"/api/products/mobile-data")
-										.param("cursorId", "1")
 										.param("size", String.valueOf(size))
 										.param("productSortOption", productSortOption)
 										.param("dataAmount", String.valueOf(dataAmount))


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 상품 조회 시 정렬 오류 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 데이터 상품 조회 시 `RECENT` 로 정렬할 경우 페이지네이션 커서 비교를 gtCursorId로 처리하면서 데이터 중복 또는 누락 문제가 발생했습니다. RECENT 정렬이 product.updatedAt DESC, product.id DESC 순으로 이뤄지기 때문에, 커서 비교 역시 내림차순(ltCursorId) 으로 맞춰야 정렬 기준과 일관성이 유지됩니다. 
이에 따라 다음과 같이 수정했습니다.
  - 정렬 조건이 RECENT인 경우 → 커서 비교를 ltCursorId로 변경
  - 그 외 정렬 조건(PRICE_ASC, AMOUNT_ASC, AMOUNT_DESC) → 기존대로 gtCursorId 유지

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #182

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?