### PR TITLE
[DP-185] feat: 매월 1일 이전 등록된 데이터 상품 상태 변경 기능

### DIFF
--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepository.java
@@ -15,19 +15,19 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductCustomRepository {
 
-	public CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, int size,
+	CursorPageResponse<MobileDataSummary> findMobileDataByCursor(Long cursorId, int size,
 			ProductSortOption productSortOption, BigDecimal dataAmount);
 
-	public CursorPageResponse<WifiSummary> findWifiByCursor(Long cursorId, int size,
+	CursorPageResponse<WifiSummary> findWifiByCursor(Long cursorId, int size,
 			ProductSortOption productSortOption, boolean isOpen, Double latitude, Double longitude);
 
-	public MobileDataInfoResponse findMobileDataInfo(Long productId, Long memberId);
+	MobileDataInfoResponse findMobileDataInfo(Long productId, Long memberId);
 
-	public WifiInfoResponse findWifiInfo(Long productId, Long memberId);
+	WifiInfoResponse findWifiInfo(Long productId, Long memberId);
 
-	public List<String> findWifiImages(Long wifiId);
+	List<String> findWifiImages(Long wifiId);
 
-	public BigDecimal sumSoldMobileDataAmountByMemberId(Long memberId);
+	BigDecimal sumSoldMobileDataAmountByMemberId(Long memberId);
 
 	List<ReadSellingProductResponse> findSellingProduct(ReadSellingProductRequest request);
 

--- a/src/main/java/com/dapanda/product/repository/ProductRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductRepository.java
@@ -2,13 +2,11 @@ package com.dapanda.product.repository;
 
 import com.dapanda.product.entity.Product;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductCustomRepository {
@@ -19,4 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
 	Optional<Product> findByIdForUpdate(@Param("id") Long id);
 
 	boolean existsByIdAndMember_Id(Long id, Long memberId);
+
+	@Query("SELECT p FROM Product p WHERE p.createdAt < :CURRENT_TIMESTAMP AND p.state = 'ACTIVE'")
+	List<Product> findAllBeforeThisMonthAndIsActive();
 }

--- a/src/main/java/com/dapanda/product/repository/ProductRepository.java
+++ b/src/main/java/com/dapanda/product/repository/ProductRepository.java
@@ -2,7 +2,6 @@ package com.dapanda.product.repository;
 
 import com.dapanda.product.entity.Product;
 import jakarta.persistence.LockModeType;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
 
 	boolean existsByIdAndMember_Id(Long id, Long memberId);
 
-	@Query("SELECT p FROM Product p WHERE p.createdAt < :CURRENT_TIMESTAMP AND p.state = 'ACTIVE'")
-	List<Product> findAllBeforeThisMonthAndIsActive();
+	@Modifying
+	@Query("UPDATE Product p SET p.state = 'HIDDEN' WHERE p.createdAt < :CURRENT_TIMESTAMP AND p.state = 'ACTIVE'")
+	void updateAllBeforeThisMonthAndIsActive();
 }

--- a/src/main/java/com/dapanda/product/service/ProductScheduler.java
+++ b/src/main/java/com/dapanda/product/service/ProductScheduler.java
@@ -1,0 +1,18 @@
+package com.dapanda.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductScheduler {
+
+	private final ProductService productService;
+
+	@Scheduled(cron = "0 0 0 1 * *") // 매월 1일 00:00 실행
+	public void hidePreviousMonthProducts() {
+
+		productService.hidePreviousMobileDataProducts();
+	}
+}

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -329,4 +329,13 @@ public class ProductService {
 		return productRepository.findMarketPrice(ItemType.valueOf(productType));
 	}
 
+	@Transactional
+	public void hidePreviousMobileDataProducts() {
+
+		List<Product> products = productRepository.findAllBeforeThisMonthAndIsActive();
+
+		for (Product product : products) {
+			product.changeState(ProductState.HIDDEN);
+		}
+	}
 }

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -212,8 +212,9 @@ public class ProductService {
 		validateProductOwner(savedProduct, memberId);
 		validateDataAmount(request.changedAmount(), savedMobileData, memberId);
 
-		int changedPricePer100MB = (int) Math.ceil(
-				request.price() / (savedMobileData.getDataAmount().floatValue() * 10));
+		int changedPricePer100MB = new BigDecimal(request.price())
+				.divide(request.changedAmount().multiply(BigDecimal.TEN), 0,
+						java.math.RoundingMode.CEILING).intValue();
 
 		savedProduct.updatePrice(request.price());
 		savedMobileData.updateMobileData(request.changedAmount(), changedPricePer100MB,

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -332,10 +332,6 @@ public class ProductService {
 	@Transactional
 	public void hidePreviousMobileDataProducts() {
 
-		List<Product> products = productRepository.findAllBeforeThisMonthAndIsActive();
-
-		for (Product product : products) {
-			product.changeState(ProductState.HIDDEN);
-		}
+		productRepository.updateAllBeforeThisMonthAndIsActive();
 	}
 }

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("상품 서비스 테스트")
@@ -990,6 +991,49 @@ class ProductServiceTest {
 				// then
 				assertThat(result.getRecentPrice()).isEqualTo(expectedRecentPrice);
 				assertThat(result.getAveragePrice()).isEqualTo(expectedAveragePrice);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("매월 1일 이전 등록된 데이터 상품 상태 변경")
+	class hidePreviousMonthProducts {
+
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
+
+			@Test
+			@DisplayName("매월 1일 이전 등록된 데이터 상품 상태 변경한다")
+			public void changeMobileDataProductState() {
+
+				// given
+				Member member = MemberFixture.createMember1WithId(MEMBER_ID);
+
+				LocalDateTime lastMonth = LocalDateTime.now().minusMonths(1).withDayOfMonth(1);
+				Product oldProduct = ProductFixture.createMobileDataProductWithId(PRODUCT_ID,
+						MOBILE_DATA_ID, PRICE_500, member);
+				ReflectionTestUtils.setField(oldProduct, "createdAt", lastMonth);
+				Product recentProduct = ProductFixture.createMobileDataProductWithId(PRODUCT_ID + 1,
+						MOBILE_DATA_ID, PRICE_500, member);
+
+				given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(oldProduct));
+				given(productRepository.findById(PRODUCT_ID + 1)).willReturn(
+						Optional.of(recentProduct));
+				given(productRepository.findAllBeforeThisMonthAndIsActive()).willReturn(
+						List.of(oldProduct));
+
+				// when
+				productService.hidePreviousMobileDataProducts();
+
+				// then
+				Product updateOldProduct = productRepository.findById(oldProduct.getId())
+						.orElseThrow();
+				Product updateRecentProduct = productRepository.findById(recentProduct.getId())
+						.orElseThrow();
+
+				assertThat(updateOldProduct.getState()).isEqualTo(ProductState.HIDDEN);
+				assertThat(updateRecentProduct.getState()).isEqualTo(ProductState.ACTIVE);
 			}
 		}
 	}

--- a/src/test/java/com/dapanda/product/service/ProductServiceTest.java
+++ b/src/test/java/com/dapanda/product/service/ProductServiceTest.java
@@ -1020,8 +1020,6 @@ class ProductServiceTest {
 				given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(oldProduct));
 				given(productRepository.findById(PRODUCT_ID + 1)).willReturn(
 						Optional.of(recentProduct));
-				given(productRepository.findAllBeforeThisMonthAndIsActive()).willReturn(
-						List.of(oldProduct));
 
 				// when
 				productService.hidePreviousMobileDataProducts();
@@ -1032,8 +1030,7 @@ class ProductServiceTest {
 				Product updateRecentProduct = productRepository.findById(recentProduct.getId())
 						.orElseThrow();
 
-				assertThat(updateOldProduct.getState()).isEqualTo(ProductState.HIDDEN);
-				assertThat(updateRecentProduct.getState()).isEqualTo(ProductState.ACTIVE);
+				verify(productRepository).updateAllBeforeThisMonthAndIsActive();
 			}
 		}
 	}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ spring:
     username: root
     password: 1234
     hikari:
-      max-lifetime: 30000  # 30초
+      max-lifetime: 60000  # 60초
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,9 +4,11 @@ spring:
     url: jdbc:tc:mysql:8.4.1://localhost:3306/tc_test?TC_REUSABLE=true
     username: root
     password: 1234
+    hikari:
+      max-lifetime: 30000  # 30초
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -16,6 +18,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+      timeout: 1000ms
+      lettuce:
+        shutdown-timeout: 100ms
       ssl:
         enabled: false
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- `@Scheduled`를 이용해 매월 1일 이전에 등록된 데이터 상품의 상태를 변경하는 기능 구현

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 관심사 분리를 위해 `ProductScheduler` 클래스를 새로 생성했습니다.
- `@Scheduled` 특성상 실행 시점을 제어하기 어려워 통합 테스트는 제외하고 단위 테스트만 작성했습니다.
- 테스트 종료 시 불필요한 에러 로그를 방지하기 위해 ddl-auto: create로 변경했습니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #188 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?