### PR TITLE
[DP-204] fix: 회원 요금제의 총량과 잔량 응답 수정

### DIFF
--- a/src/main/java/com/dapanda/plan/dto/response/PlanInfoResponse.java
+++ b/src/main/java/com/dapanda/plan/dto/response/PlanInfoResponse.java
@@ -20,7 +20,7 @@ public class PlanInfoResponse {
 		return PlanInfoResponse.builder().
 				name(plan.getName()).
 				currentDataAmount(plan.getCurrentDataAmount()).
-				providingDataAmount(plan.getCurrentDataAmount()).
+				providingDataAmount(plan.getProvidingDataAmount()).
 				monthlyPrice(plan.getMonthlyPrice()).
 				build();
 	}

--- a/src/main/java/com/dapanda/product/service/ProductService.java
+++ b/src/main/java/com/dapanda/product/service/ProductService.java
@@ -217,11 +217,7 @@ public class ProductService {
 		MobileData savedMobileData = mobileDataRepository.findById(savedProduct.getItemId())
 				.orElseThrow(() -> new GlobalException(ResultCode.PRODUCT_NOT_FOUND));
 
-		if (tradeRepository.existsByProductId(request.productId())
-				&& savedMobileData.isSplitType()) {
-			throw new GlobalException(ResultCode.PRODUCT_CANNOT_TRADE);
-		}
-
+		validateProductTradeAvailability(request.productId(), savedMobileData);
 		validateProductOwner(savedProduct, memberId);
 		validateDataAmount(request.changedAmount(), savedMobileData, memberId);
 
@@ -370,4 +366,11 @@ public class ProductService {
 
 		productRepository.updateAllBeforeThisMonthAndIsActive();
 	}
+
+	private void validateProductTradeAvailability(Long productId, MobileData mobileData) {
+		if (tradeRepository.existsByProductId(productId) && mobileData.isSplitType()) {
+			throw new GlobalException(ResultCode.PRODUCT_CANNOT_TRADE);
+		}
+	}
+
 }

--- a/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/dapanda/plan/service/PlanServiceTest.java
@@ -107,6 +107,7 @@ class PlanServiceTest {
 				when(planRepository.findByMemberId(memberId)).thenReturn(Optional.of(plan));
 				when(plan.getName()).thenReturn("프리미엄");
 				when(plan.getCurrentDataAmount()).thenReturn(BigDecimal.valueOf(30.0));
+				when(plan.getProvidingDataAmount()).thenReturn(BigDecimal.valueOf(30.0));
 				when(plan.getMonthlyPrice()).thenReturn(25000);
 
 				// when
@@ -115,6 +116,8 @@ class PlanServiceTest {
 				// then
 				assertThat(result).isNotNull();
 				assertThat(result.getName()).isEqualTo("프리미엄");
+				assertThat(result.getCurrentDataAmount()).isEqualByComparingTo(
+						BigDecimal.valueOf(30.0));
 				assertThat(result.getProvidingDataAmount()).isEqualByComparingTo(
 						BigDecimal.valueOf(30.0));
 				assertThat(result.getMonthlyPrice()).isEqualTo(25000);


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 회원 요금제의 총량과 잔량 응답이 같은 값이 오던 에러를 수정하였습니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #211 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?