### PR TITLE
[DP-214] fix: 데이터 상품 목록 조회 시 가격 낮은순 정렬 오류 수정

### DIFF
--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -66,7 +66,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						eqDataAmount(dataAmount)
 				)
 				.orderBy(
-						productSortOption == ProductSortOption.PRICE_ASC ? product.price.asc() :
+						productSortOption == ProductSortOption.PRICE_ASC
+								? mobileData.pricePer100MB.asc() :
 								productSortOption == ProductSortOption.AMOUNT_ASC
 										? mobileData.remainAmount.asc() :
 										productSortOption == ProductSortOption.AMOUNT_DESC


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 상품 목록 조회 시 가격 낮은순으로 정렬을 할 때 pricePer100MB가 아니라 상품의 가격으로 정렬되는 오류를 수정했습니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #220

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?