### PR TITLE
[DP-220] feat: 채팅 메시지 응답에 채팅방 아이디 추가

### DIFF
--- a/src/main/java/com/dapanda/chat/dto/response/CreateMessageResponse.java
+++ b/src/main/java/com/dapanda/chat/dto/response/CreateMessageResponse.java
@@ -10,16 +10,19 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateMessageResponse {
 
+	private Long chatRoomId;
 	private Long chatMessageId;
 	private String message;
 	private LocalDateTime createdAt;
 
 	public static CreateMessageResponse of(
+			Long chatRoomId,
 			Long chatMessageId,
 			String message,
 			LocalDateTime createdAt) {
 
 		return CreateMessageResponse.builder()
+				.chatRoomId(chatRoomId)
 				.chatMessageId(chatMessageId)
 				.message(message)
 				.createdAt(createdAt)

--- a/src/main/java/com/dapanda/chat/entity/ChatMessageReadStatus.java
+++ b/src/main/java/com/dapanda/chat/entity/ChatMessageReadStatus.java
@@ -35,4 +35,9 @@ public class ChatMessageReadStatus {
 				.chatMessage(chatMessage)
 				.build();
 	}
+
+	public void updateLastReadChatMessage(ChatMessage chatMessage) {
+
+		this.chatMessage = chatMessage;
+	}
 }

--- a/src/main/java/com/dapanda/chat/repository/ChatMessageReadStatusRepository.java
+++ b/src/main/java/com/dapanda/chat/repository/ChatMessageReadStatusRepository.java
@@ -1,14 +1,13 @@
 package com.dapanda.chat.repository;
 
-import com.dapanda.chat.entity.*;
+import com.dapanda.chat.entity.ChatMessageReadStatus;
+import com.dapanda.chat.entity.ChatRoom;
 import com.dapanda.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessageReadStatus, Long> {
-
-	Optional<ChatMessageReadStatus> findFirstByChatRoomAndChatMessageAndMember(ChatRoom chatRoom, ChatMessage chatMessage, Member member);
 
 	Optional<ChatMessageReadStatus> findFirstByChatRoomAndMember(ChatRoom chatRoom, Member member);
 }

--- a/src/main/java/com/dapanda/chat/repository/ChatMessageReadStatusRepository.java
+++ b/src/main/java/com/dapanda/chat/repository/ChatMessageReadStatusRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessageReadStatus, Long> {
 
 	Optional<ChatMessageReadStatus> findFirstByChatRoomAndChatMessageAndMember(ChatRoom chatRoom, ChatMessage chatMessage, Member member);
+
+	Optional<ChatMessageReadStatus> findFirstByChatRoomAndMember(ChatRoom chatRoom, Member member);
 }

--- a/src/main/java/com/dapanda/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dapanda/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,4 @@ import com.dapanda.chat.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
-
-	boolean existsByIdAndMember_IdAndChatRoom_Id(Long id, Long memberId, Long chatRoomId);
 }

--- a/src/main/java/com/dapanda/chat/service/ChatService.java
+++ b/src/main/java/com/dapanda/chat/service/ChatService.java
@@ -145,7 +145,7 @@ public class ChatService {
 
 		chatRoom.updateLastMessage(chatMessage);
 
-		return CreateMessageResponse.of(chatMessage.getId(), request.message(), chatMessage.getCreatedAt());
+		return CreateMessageResponse.of(chatRoomId, chatMessage.getId(), request.message(), chatMessage.getCreatedAt());
 	}
 
 	@Transactional

--- a/src/main/java/com/dapanda/chat/service/ChatService.java
+++ b/src/main/java/com/dapanda/chat/service/ChatService.java
@@ -163,11 +163,11 @@ public class ChatService {
 
 		Member member = memberRepository.getReferenceById(memberId);
 
-		ChatMessageReadStatus chatMessageReadStatus = ChatMessageReadStatus.of(
-				member,
-				chatMessage.getChatRoom(),
-				chatMessage
-		);
+		ChatMessageReadStatus chatMessageReadStatus = chatMessageReadStatusRepository
+				.findFirstByChatRoomAndMember(chatMessage.getChatRoom(), member)
+				.orElseGet(() -> ChatMessageReadStatus.of(member, chatMessage.getChatRoom(), chatMessage));
+
+		chatMessageReadStatus.updateLastReadChatMessage(chatMessage);
 
 		chatMessageReadStatusRepository.save(chatMessageReadStatus);
 	}

--- a/src/test/java/com/dapanda/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/dapanda/chat/controller/ChatControllerTest.java
@@ -499,7 +499,7 @@ class ChatControllerTest {
 						));
 
 				ChatMessageReadStatus savedReadStatus = chatMessageReadStatusRepository
-						.findFirstByChatRoomAndChatMessageAndMember(chatRoom, lastChatMessage, buyer)
+						.findFirstByChatRoomAndMember(chatRoom, buyer)
 						.orElseThrow();
 
 				assertThat(savedReadStatus.getChatMessage().getId()).isEqualTo(lastChatMessage.getId());


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 채팅 메시지 응답에 채팅방 아이디 추가
   - 채팅방 목록 조회에서 받은 메시지의 채팅방 아이디를 통해 특정 채팅방에서 읽지 않은 메시지를 카운트 합니다 

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #228 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?