### PR TITLE
[DP-222] docs: 회원 프로필 이미지 변경 API RestDocs에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ out/
 
 ### REST Docs ###
 /src/main/resources/static/*
+
+
+### Firebase ###
+src/main/resources/firebase/firebase-service-account.json

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -727,6 +727,41 @@ include::{snippets}/member/get-other-info/response-fields.adoc[]
 include::{snippets}/member/get-member-info-notfound/http-request.adoc[]
 include::{snippets}/member/get-member-info-notfound/http-response.adoc[]
 
+==== 프로필 이미지 변경
+
+`POST /api/members/profile-image`
+
+회원의 프로필 이미지를 변경합니다.
+
+===== 요청
+
+include::{snippets}/member/post-profile-image-success/http-request.adoc[]
+
+===== 요청 필드
+
+include::{snippets}/member/post-profile-image-success/request-fields.adoc[]
+
+===== 응답
+
+include::{snippets}/member/post-profile-image-success/http-response.adoc[]
+
+===== 응답 필드
+
+include::{snippets}/member/post-profile-image-success/response-fields.adoc[]
+
+===== 실패 요청
+
+====== 지원하지 않는 확장자
+
+include::{snippets}/member/post-profile-image-invalid-extension-error/http-request.adoc[]
+include::{snippets}/member/post-profile-image-invalid-extension-error/http-response.adoc[]
+
+====== 빈 이미지 URL
+
+include::{snippets}/member/post-profile-image-blank-url-error/http-request.adoc[]
+include::{snippets}/member/post-profile-image-blank-url-error/http-response.adoc[]
+
+
 ---
 
 [[resources-product]]

--- a/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
@@ -189,124 +189,6 @@ class MemberControllerTest {
 	}
 
 	@Nested
-	@DisplayName("프로필 이미지 변경 API")
-	class UpdateProfileImage {
-
-		@Nested
-		@DisplayName("성공 케이스")
-		class Success {
-
-			@Test
-			@DisplayName("정상적으로 프로필 이미지를 변경한다")
-			void updateProfileImage_success() throws Exception {
-				// given
-				Member member = MemberFixture.createMember1();
-				memberRepository.save(member);
-				CustomUserDetails userDetails = CustomUserDetails.from(member);
-
-				String imageUrl = "https://dapanda.org/profile/test.jpg";
-				var request = new UpdateProfileImageRequest(imageUrl);
-
-				// when & then
-				mockMvc.perform(
-								MockMvcRequestBuilders.post("/api/members/profile-image")
-										.contentType(MediaType.APPLICATION_JSON)
-										.content(objectMapper.writeValueAsString(request))
-										.with(authentication(new UsernamePasswordAuthenticationToken(
-												userDetails, null, userDetails.getAuthorities()
-										)))
-						)
-						.andExpect(status().isOk())
-						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
-						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
-						.andDo(document("member/post-profile-image-success",
-								requestFields(
-										fieldWithPath("imageUrl").description("프로필 이미지 URL")
-								),
-								responseFields(
-										fieldWithPath("code").description("상태 코드"),
-										fieldWithPath("message").description("처리 결과 메시지")
-								)
-						));
-
-			}
-		}
-
-		@Nested
-		@DisplayName("실패 케이스")
-		class Fail {
-
-			@Test
-			@DisplayName("유효하지 않은 확장자일 때 예외를 반환한다")
-			void updateProfileImage_invalidExtension() throws Exception {
-				// given
-				Member member = MemberFixture.createMember1();
-				memberRepository.save(member);
-				CustomUserDetails userDetails = CustomUserDetails.from(member);
-
-				String imageUrl = "https://dapanda.org/profile/test.gif"; // gif 확장자 (지원 안함)
-				var request = new UpdateProfileImageRequest(imageUrl);
-
-				// when & then
-				mockMvc.perform(
-								MockMvcRequestBuilders.post("/api/members/profile-image")
-										.contentType(MediaType.APPLICATION_JSON)
-										.content(objectMapper.writeValueAsString(request))
-										.with(authentication(new UsernamePasswordAuthenticationToken(
-												userDetails, null, userDetails.getAuthorities()
-										)))
-						)
-						.andExpect(status().isBadRequest())
-						.andExpect(
-								jsonPath("$.code").value(ResultCode.INVALID_IMAGE_FORMAT.getCode()))
-						.andExpect(jsonPath("$.message").value(
-								ResultCode.INVALID_IMAGE_FORMAT.getMessage()))
-						.andDo(document("member/post-profile-image-invalid-extension-error",
-								requestFields(
-										fieldWithPath("imageUrl").description("프로필 이미지 URL")
-								),
-								responseFields(
-										fieldWithPath("code").description("상태 코드"),
-										fieldWithPath("message").description("에러 메시지")
-								)
-						));
-
-			}
-
-			@Test
-			@DisplayName("이미지 URL이 빈 값이면 예외를 반환한다")
-			void updateProfileImage_blankImageUrl() throws Exception {
-				// given
-				Member member = MemberFixture.createMember1();
-				memberRepository.save(member);
-				CustomUserDetails userDetails = CustomUserDetails.from(member);
-
-				var request = new UpdateProfileImageRequest("");
-
-				// when & then
-				mockMvc.perform(
-								MockMvcRequestBuilders.post("/api/members/profile-image")
-										.contentType(MediaType.APPLICATION_JSON)
-										.content(objectMapper.writeValueAsString(request))
-										.with(authentication(new UsernamePasswordAuthenticationToken(
-												userDetails, null, userDetails.getAuthorities()
-										)))
-						)
-						.andDo(document("member/post-profile-image-blank-url-error",
-								requestFields(
-										fieldWithPath("imageUrl").description("프로필 이미지 URL")
-								),
-								responseFields(
-										fieldWithPath("code").description("상태 코드"),
-										fieldWithPath("message").description("에러 메시지")
-								)
-						));
-
-			}
-		}
-	}
-
-	@Nested
 	@DisplayName("회원 정보 조회 API")
 	class GetMemberInfo {
 
@@ -438,6 +320,122 @@ class MemberControllerTest {
 
 		}
 
+	}
+
+	@Nested
+	@DisplayName("프로필 이미지 변경 API")
+	class UpdateProfileImage {
+
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
+
+			@Test
+			@DisplayName("정상적으로 프로필 이미지를 변경한다")
+			void updateProfileImage_success() throws Exception {
+
+				// given
+				Member member = memberRepository.save(MemberFixture.createMember1());
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+				String imageUrl = "https://dapanda.org/profile/test.jpg"; // 유효한 확장자
+				var request = new UpdateProfileImageRequest(imageUrl);
+
+				// when & then
+				mockMvc.perform(
+								MockMvcRequestBuilders.post("/api/members/profile-image")
+										.contentType(MediaType.APPLICATION_JSON)
+										.content(objectMapper.writeValueAsString(request))
+										.with(authentication(new UsernamePasswordAuthenticationToken(
+												userDetails, null, userDetails.getAuthorities()
+										)))
+						)
+						.andExpect(status().isOk())
+						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
+						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
+						.andDo(document("member/post-profile-image-success",
+								requestFields(
+										fieldWithPath("imageUrl").description("프로필 이미지 URL")
+								),
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("처리 결과 메시지")
+								)
+						));
+			}
+		}
+
+		@Nested
+		@DisplayName("실패 케이스")
+		class Fail {
+
+			@Test
+			@DisplayName("지원하지 않는 이미지 확장자면 예외를 반환한다")
+			void updateProfileImage_invalidExtension() throws Exception {
+
+				// given
+				Member member = memberRepository.save(MemberFixture.createMember1());
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+				String imageUrl = "https://dapanda.org/profile/invalid.bmp"; // 지원하지 않는 확장자
+				var request = new UpdateProfileImageRequest(imageUrl);
+
+				// when & then
+				mockMvc.perform(
+								MockMvcRequestBuilders.post("/api/members/profile-image")
+										.contentType(MediaType.APPLICATION_JSON)
+										.content(objectMapper.writeValueAsString(request))
+										.with(authentication(new UsernamePasswordAuthenticationToken(
+												userDetails, null, userDetails.getAuthorities()
+										)))
+						)
+						.andExpect(status().isBadRequest())
+						.andExpect(
+								jsonPath("$.code").value(ResultCode.INVALID_IMAGE_FORMAT.getCode()))
+						.andExpect(jsonPath("$.message").value(
+								ResultCode.INVALID_IMAGE_FORMAT.getMessage()))
+						.andDo(document("member/post-profile-image-invalid-extension-error",
+								requestFields(
+										fieldWithPath("imageUrl").description("프로필 이미지 URL")
+								),
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("에러 메시지")
+								)
+						));
+			}
+
+			@Test
+			@DisplayName("이미지 URL이 빈 값이면 예외를 반환한다")
+			void updateProfileImage_blankImageUrl() throws Exception {
+
+				// given
+				Member member = memberRepository.save(MemberFixture.createMember1());
+				CustomUserDetails userDetails = CustomUserDetails.from(member);
+				var request = new UpdateProfileImageRequest("");
+
+				// when & then
+				mockMvc.perform(
+								MockMvcRequestBuilders.post("/api/members/profile-image")
+										.contentType(MediaType.APPLICATION_JSON)
+										.content(objectMapper.writeValueAsString(request))
+										.with(authentication(new UsernamePasswordAuthenticationToken(
+												userDetails, null, userDetails.getAuthorities()
+										)))
+						)
+						.andExpect(status().isBadRequest())
+						.andExpect(jsonPath("$.code").value(ResultCode.INVALID_PARAMETER.getCode()))
+						.andExpect(jsonPath("$.message").exists())
+						.andDo(document("member/post-profile-image-blank-url-error",
+								requestFields(
+										fieldWithPath("imageUrl").description(
+												"프로필 이미지 URL (비어있으면 안 됨)")
+								),
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("에러 메시지")
+								)
+						));
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 회원의 프로필 이미지 변경 API를 RestDocs에 추가하였습니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #230 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?