### PR TITLE
[DP-246] fix: 와이파이 상품 판매 시세 조회 수정

### DIFF
--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -525,7 +525,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
 		// 와이파이 상품
 		Integer recentPrice = queryFactory
-				.select(trade.tradingPrice)
+				.select(trade.tradingPrice.multiply(10).divide(trade.timeAmount)) // 10분당 가격
 				.from(trade)
 				.where(
 						trade.tradeType.eq(TradeType.SALE_WIFI),
@@ -536,7 +536,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.fetchOne();
 
 		Double averagePrice = queryFactory
-				.select(trade.tradingPrice.avg())
+				.select(
+						trade.tradingPrice.multiply(10).divide(trade.timeAmount).avg()
+				)
 				.from(trade)
 				.where(
 						trade.tradeType.eq(TradeType.SALE_WIFI),


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 와이파이 상품 판매 시세 조회 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 기존에는 와이파이 상품 판매 시세 조회 시 전체 거래 가격을 그대로 반환하고 있었습니다.
- 이를 10분 단위 가격으로 계산되도록 수정하여 `tradingPrice * 10 / timeAmount` 로 반환되도록 쿼리를 수정했습니다.
- 최근가 및 평균가 모두 10분 단가 기준으로 집계됩니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #249

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?