### PR TITLE
[DP-261] fix: 배포 실패로 인한 RedisConfig 사용하지 않는 Bean 임시 주석

### DIFF
--- a/src/main/java/com/dapanda/common/config/RedisConfig.java
+++ b/src/main/java/com/dapanda/common/config/RedisConfig.java
@@ -1,23 +1,14 @@
 package com.dapanda.common.config;
 
-import com.dapanda.chat.service.RedisPubSubService;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.*;
 
@@ -31,45 +22,45 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
-	@Bean
-	@Qualifier("chatPubSub")
-	public RedisConnectionFactory chatPubSubFactor() {
-
-		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
-
-		configuration.setHostName(host);
-		configuration.setPort(port);
-
-		return new LettuceConnectionFactory(configuration);
-	}
-
-	@Bean
-	@Qualifier("chatPubSub")
-	public StringRedisTemplate stringRedisTemplate(
-			@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory) {
-
-		return new StringRedisTemplate(redisConnectionFactory);
-	}
-
-	@Bean
-	public RedisMessageListenerContainer redisMessageListenerContainer(
-			@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory,
-			MessageListenerAdapter messageListenerAdapter) {
-
-		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-
-		container.setConnectionFactory(redisConnectionFactory);
-		container.addMessageListener(messageListenerAdapter, new PatternTopic("chat"));
-
-		return container;
-	}
-
-	@Bean
-	public MessageListenerAdapter messageListenerAdapter(RedisPubSubService redisPubSubService) {
-
-		// RedisPubSubService 의 특정 메서드가 수신된 메시지를 처리할수 있도록 지정
-		return new MessageListenerAdapter(redisPubSubService, "onMessage");
-	}
+//	@Bean
+//	@Qualifier("chatPubSub")
+//	public RedisConnectionFactory chatPubSubFactor() {
+//
+//		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+//
+//		configuration.setHostName(host);
+//		configuration.setPort(port);
+//
+//		return new LettuceConnectionFactory(configuration);
+//	}
+//
+//	@Bean
+//	@Qualifier("chatPubSub")
+//	public StringRedisTemplate stringRedisTemplate(
+//			@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory) {
+//
+//		return new StringRedisTemplate(redisConnectionFactory);
+//	}
+//
+//	@Bean
+//	public RedisMessageListenerContainer redisMessageListenerContainer(
+//			@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory,
+//			MessageListenerAdapter messageListenerAdapter) {
+//
+//		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+//
+//		container.setConnectionFactory(redisConnectionFactory);
+//		container.addMessageListener(messageListenerAdapter, new PatternTopic("chat"));
+//
+//		return container;
+//	}
+//
+//	@Bean
+//	public MessageListenerAdapter messageListenerAdapter(RedisPubSubService redisPubSubService) {
+//
+//		// RedisPubSubService 의 특정 메서드가 수신된 메시지를 처리할수 있도록 지정
+//		return new MessageListenerAdapter(redisPubSubService, "onMessage");
+//	}
 
 	@Bean
 	public GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer() {


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- redisMessageListenerContainer 빈이 초기화되지 않아 배포를 실패하여 임시 주석처리 했습니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #262

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?