### PR TITLE
[DP-271] fix: 데이터 상품 자투리 조회 판매자 이미지 URL 추가

### DIFF
--- a/src/main/java/com/dapanda/fcmToken/controller/FcmTokenController.java
+++ b/src/main/java/com/dapanda/fcmToken/controller/FcmTokenController.java
@@ -2,9 +2,9 @@ package com.dapanda.fcmToken.controller;
 
 import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.common.exception.CommonResponse;
-import com.dapanda.fcmToken.dto.SaveFcmTokenRequest;
+import com.dapanda.fcmToken.dto.request.SaveFcmTokenRequest;
+import com.dapanda.fcmToken.dto.response.NotificationResponse;
 import com.dapanda.fcmToken.service.FcmTokenService;
-import com.dapanda.fcm_token.dto.response.NotificationResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/dapanda/fcmToken/dto/request/SaveFcmTokenRequest.java
+++ b/src/main/java/com/dapanda/fcmToken/dto/request/SaveFcmTokenRequest.java
@@ -1,4 +1,4 @@
-package com.dapanda.fcmToken.dto;
+package com.dapanda.fcmToken.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/com/dapanda/fcmToken/dto/response/NotificationResponse.java
+++ b/src/main/java/com/dapanda/fcmToken/dto/response/NotificationResponse.java
@@ -1,4 +1,4 @@
-package com.dapanda.fcm_token.dto.response;
+package com.dapanda.fcmToken.dto.response;
 
 import com.dapanda.fcm_token.entity.NotificationEntity;
 import java.time.LocalDateTime;

--- a/src/main/java/com/dapanda/fcmToken/service/FcmTokenService.java
+++ b/src/main/java/com/dapanda/fcmToken/service/FcmTokenService.java
@@ -2,10 +2,10 @@ package com.dapanda.fcmToken.service;
 
 import com.dapanda.common.exception.GlobalException;
 import com.dapanda.common.exception.ResultCode;
+import com.dapanda.fcmToken.dto.response.NotificationResponse;
 import com.dapanda.fcmToken.entity.FcmToken;
 import com.dapanda.fcmToken.repository.FcmTokenRepository;
 import com.dapanda.fcmToken.repository.NotificationRepository;
-import com.dapanda.fcm_token.dto.response.NotificationResponse;
 import com.dapanda.fcm_token.entity.NotificationEntity;
 import com.dapanda.member.entity.Member;
 import com.dapanda.member.repository.MemberRepository;

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -19,6 +19,7 @@ import com.dapanda.trade.dto.MobileDataScrap;
 import com.dapanda.trade.entity.TradeType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
@@ -247,6 +248,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 			cursorCondition.and((product.id.lt(request.cursorId())));
 		}
 
+		Expression<String> imageUrlExpr =
+				productImage.imageUrl.coalesce("").as("productImageUrl");
+
 		List<Tuple> tuples = queryFactory
 				.select(
 						product.id,
@@ -257,7 +261,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						wifi.startTime,
 						wifi.endTime,
 						wifi.title,
-						productImage.imageUrl.coalesce(""),
+						imageUrlExpr,
 						product.createdAt,
 						product.updatedAt
 				)
@@ -273,14 +277,16 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				.leftJoin(productImage).on(
 						productImage.wifiId.eq(wifi.id)
 								.and(productImage.priority.eq(
-										JPAExpressions.select(productImageSub.priority.min())
+										JPAExpressions.select(
+														productImageSub.priority.min())
 												.from(productImageSub)
 												.where(productImageSub.wifiId.eq(wifi.id))
 								))
 				)
 				.where(
 						product.member.id.eq(request.memberId()),
-						request.productState() != null ? product.state.eq(request.productState())
+						request.productState() != null ? product.state.eq(
+								request.productState())
 								: null,
 						cursorCondition
 				)
@@ -313,7 +319,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 							tuple.get(wifi.startTime),
 							tuple.get(wifi.endTime),
 							tuple.get(wifi.title),
-							tuple.get(productImage.imageUrl),
+							tuple.get(imageUrlExpr),
 							tuple.get(product.createdAt),
 							tuple.get(product.updatedAt)
 					);

--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -329,6 +329,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 						product.id,
 						mobileData.id,
 						product.member.name,
+						product.member.profileImageUrl.coalesce(""),
 						product.price,
 						Expressions.constant(0),
 						mobileData.remainAmount,

--- a/src/main/java/com/dapanda/trade/dto/MobileDataScrap.java
+++ b/src/main/java/com/dapanda/trade/dto/MobileDataScrap.java
@@ -12,6 +12,7 @@ public class MobileDataScrap {
 	private Long productId;
 	private Long mobileDataId;
 	private String memberName;
+	private String profileImageUrl;
 	private int price;
 	private int purchasePrice;
 	private BigDecimal remainAmount;

--- a/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
+++ b/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
@@ -15,5 +15,6 @@ public class PurchaseHistorySummary {
 	private BigDecimal dataAmount; // 데이터 상품
 	private String title; // 와이파이 상품
 	private String productImageUrl; // 와이파이 상품
+	private Integer timeAmount; // 와이파이 상품
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
@@ -41,6 +41,7 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 						trade.dataAmount.coalesce(new BigDecimal("0")),
 						wifi.title.coalesce(""),
 						productImage.imageUrl.coalesce(""),
+						trade.timeAmount.coalesce(0),
 						trade.createdAt
 				))
 				.from(trade)

--- a/src/main/java/com/dapanda/trade/service/TradeService.java
+++ b/src/main/java/com/dapanda/trade/service/TradeService.java
@@ -142,6 +142,7 @@ public class TradeService {
 							item.getProductId(),
 							item.getMobileDataId(),
 							item.getMemberName(),
+							item.getProfileImageUrl(),
 							item.getPrice(),
 							(int) (needed.doubleValue() * 10 * item.getPricePer100MB()),
 							// purchasePrice
@@ -160,6 +161,7 @@ public class TradeService {
 							item.getProductId(),
 							item.getMobileDataId(),
 							item.getMemberName(),
+							item.getProfileImageUrl(),
 							item.getPrice(),
 							item.getPrice(), // purchasePrice
 							item.getRemainAmount(),
@@ -425,7 +427,7 @@ public class TradeService {
 
 		} else {
 			product.updatePrice(product.getPrice() - price);
-			mobileData.update100MBPerPrice(price, mobileData.getRemainAmount());
+			mobileData.update100MBPerPrice(product.getPrice(), mobileData.getRemainAmount());
 		}
 	}
 

--- a/src/test/java/com/dapanda/fcm/controller/FcmTokenControllerTest.java
+++ b/src/test/java/com/dapanda/fcm/controller/FcmTokenControllerTest.java
@@ -11,7 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.dapanda.TestConfig;
 import com.dapanda.auth.entity.CustomUserDetails;
-import com.dapanda.fcmToken.dto.SaveFcmTokenRequest;
+import com.dapanda.fcmToken.dto.request.SaveFcmTokenRequest;
 import com.dapanda.fcmToken.repository.NotificationRepository;
 import com.dapanda.fcmToken.service.FcmTokenService;
 import com.dapanda.fcm_token.entity.NotificationEntity;

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -1264,6 +1264,7 @@ class TradeControllerTest {
 						.andExpect(jsonPath("$.data.trades.data[0].dataAmount").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].title").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].productImageUrl").exists())
+						.andExpect(jsonPath("$.data.trades.data[0].timeAmount").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].createdAt").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo.size").exists())
@@ -1296,6 +1297,8 @@ class TradeControllerTest {
 										fieldWithPath(
 												"data.trades.data[].productImageUrl").description(
 												"거래 상품 대표 이미지 URL (와이파이)"),
+										fieldWithPath("data.trades.data[].timeAmount").description(
+												"거래 시간양 (와이파이)"),
 										fieldWithPath("data.trades.data[].createdAt").description(
 												"거래 생성 시간"),
 										fieldWithPath("data.trades.pageInfo").description("페이지 정보"),

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -567,6 +567,9 @@ class TradeControllerTest {
 												"데이터 가격"),
 										fieldWithPath("data.combinations[].memberName").description(
 												"판매자 이름"),
+										fieldWithPath(
+												"data.combinations[].profileImageUrl").description(
+												"판매자 프로필 이미지 URL"),
 										fieldWithPath("data.combinations[].price").description(
 												"상품 가격"),
 										fieldWithPath(
@@ -745,6 +748,8 @@ class TradeControllerTest {
 												"데이터 가격"),
 										fieldWithPath("combinations[].memberName").description(
 												"판매자 이름"),
+										fieldWithPath("combinations[].profileImageUrl").description(
+												"판매자 프로필 이미지 URL"),
 										fieldWithPath("combinations[].price").description(
 												"상품 가격"),
 										fieldWithPath(
@@ -866,6 +871,8 @@ class TradeControllerTest {
 												"데이터 가격"),
 										fieldWithPath("combinations[].memberName").description(
 												"판매자 이름"),
+										fieldWithPath("combinations[].profileImageUrl").description(
+												"판매자 프로필 이미지 URL"),
 										fieldWithPath("combinations[].price").description(
 												"상품 가격"),
 										fieldWithPath(
@@ -966,6 +973,8 @@ class TradeControllerTest {
 												"데이터 가격"),
 										fieldWithPath("combinations[].memberName").description(
 												"판매자 이름"),
+										fieldWithPath("combinations[].profileImageUrl").description(
+												"판매자 프로필 이미지 URL"),
 										fieldWithPath("combinations[].price").description(
 												"상품 가격"),
 										fieldWithPath(

--- a/src/test/java/com/dapanda/trade/entity/TradeFixture.java
+++ b/src/test/java/com/dapanda/trade/entity/TradeFixture.java
@@ -32,7 +32,7 @@ public class TradeFixture {
 			int purchasePrice, BigDecimal purchaseDataAmount) {
 
 		return new MobileDataScrap(product.getId(), mobileData.getId(),
-				product.getMember().getName(), product.getPrice(), purchasePrice,
+				product.getMember().getName(), "", product.getPrice(), purchasePrice,
 				mobileData.getRemainAmount(), purchaseDataAmount, mobileData.getPricePer100MB(),
 				mobileData.isSplitType(), product.getUpdatedAt());
 	}

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -746,6 +746,7 @@ class TradeServiceTest {
 						BigDecimal.valueOf(0),
 						TITLE,
 						PROFILE_IMAGE_URL,
+						10,
 						trade1.getCreatedAt()
 				);
 
@@ -756,6 +757,7 @@ class TradeServiceTest {
 						BigDecimal.valueOf(0),
 						TITLE + 1,
 						PROFILE_IMAGE_URL,
+						10,
 						trade2.getCreatedAt()
 				);
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 데이터 상품 자투리 조회 판매자 이미지 URL 추가
- 상품 구매 내역 조회 시 와이파이 이용 시간 반환 추가
- 판매 내역 조회 시 와이파이 상품 이미지 URL 조회 쿼리 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- hotfix들 사항이라 이슈를 나누지 못했습니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #270 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?