### PR TITLE
[DP-273] fix: 회원 정보 조회 시 회원 아이디 반환

### DIFF
--- a/src/main/java/com/dapanda/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/dapanda/member/dto/response/MemberInfoResponse.java
@@ -9,6 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberInfoResponse {
 
+	private Long memberId;
 	private String name;
 	private String profileImageUrl;
 	private LocalDate joinedAt;
@@ -17,6 +18,7 @@ public class MemberInfoResponse {
 	private int tradeCount;
 
 	public static MemberInfoResponse of(
+			Long memberId,
 			String name,
 			String profileImageUrl,
 			LocalDate joinedAt,
@@ -25,6 +27,7 @@ public class MemberInfoResponse {
 			int tradeCount
 	) {
 		return MemberInfoResponse.builder()
+				.memberId(memberId)
 				.name(name)
 				.profileImageUrl(profileImageUrl)
 				.joinedAt(joinedAt)

--- a/src/main/java/com/dapanda/member/service/MemberService.java
+++ b/src/main/java/com/dapanda/member/service/MemberService.java
@@ -193,6 +193,7 @@ public class MemberService {
 		Long tradeCount = tradeRepository.countTradeHistoryByMemberId(memberId);
 
 		return MemberInfoResponse.of(
+				memberId,
 				member.getName(),
 				member.getProfileImageUrl(),
 				member.getCreatedAt().toLocalDate(),

--- a/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
@@ -286,6 +286,7 @@ class MemberControllerTest {
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").exists())
 						.andExpect(jsonPath("$.message").exists())
+						.andExpect(jsonPath("$.data.memberId").value(member.getId()))
 						.andExpect(jsonPath("$.data.name").value(member.getName()))
 						.andExpect(
 								jsonPath("$.data.profileImageUrl").value(
@@ -299,6 +300,7 @@ class MemberControllerTest {
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
 										fieldWithPath("message").description("처리 결과 메시지"),
+										fieldWithPath("data.memberId").description("회원 아이디"),
 										fieldWithPath("data.name").description("회원 이름"),
 										fieldWithPath("data.profileImageUrl").description(
 												"프로필 이미지 URL"),
@@ -333,6 +335,7 @@ class MemberControllerTest {
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").exists())
 						.andExpect(jsonPath("$.message").exists())
+						.andExpect(jsonPath("$.data.memberId").value(other.getId()))
 						.andExpect(jsonPath("$.data.name").value(other.getName()))
 						.andExpect(jsonPath("$.data.profileImageUrl").value(
 								other.getProfileImageUrl()))
@@ -344,6 +347,7 @@ class MemberControllerTest {
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
 										fieldWithPath("message").description("처리 결과 메시지"),
+										fieldWithPath("data.memberId").description("회원 아이디"),
 										fieldWithPath("data.name").description("회원 이름"),
 										fieldWithPath("data.profileImageUrl").description(
 												"프로필 이미지 URL"),


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 프론트의 요청으로 회원 정보 조회 시 회원 아이디를 반환하도록 수정했습니다!

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #275

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?