### PR TITLE
[DP-292] feat: 최초 사용자 역할 변경 기능

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -92,6 +92,20 @@ DaPanda 서비스의 REST API 문서입니다.
 [[resources-member]]
 === 회원
 
+==== 회원 역할 변경
+
+===== 요청
+
+include::{snippets}/member/update-member-role/http-request.adoc[]
+
+===== 응답
+
+include::{snippets}/member/update-member-role/http-response.adoc[]
+
+===== 응답 필드
+
+include::{snippets}/member/update-member-role/response-fields.adoc[]
+
 ==== 캐시 조회
 
 `GET` 회원이 보유한 캐시 조회

--- a/src/main/java/com/dapanda/member/controller/MemberController.java
+++ b/src/main/java/com/dapanda/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
 		memberService.updateMemberRole(userDetails.getId());
 
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+		return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success(null));
 	}
 
 	@GetMapping("/members/cash")

--- a/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dapanda/member/controller/MemberControllerTest.java
@@ -1,13 +1,5 @@
 package com.dapanda.member.controller;
 
-import static com.dapanda.TestConstants.Member.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.dapanda.TestConfig;
 import com.dapanda.auth.entity.CustomUserDetails;
 import com.dapanda.common.exception.ResultCode;
@@ -20,7 +12,6 @@ import com.dapanda.product.repository.MobileDataRepository;
 import com.dapanda.product.repository.ProductRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
-import java.math.BigDecimal;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +27,17 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.math.BigDecimal;
+
+import static com.dapanda.TestConstants.Member.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -503,6 +505,39 @@ class MemberControllerTest {
 										fieldWithPath("imageUrl").description(
 												"프로필 이미지 URL (비어있으면 안 됨)")
 								),
+								responseFields(
+										fieldWithPath("code").description("상태 코드"),
+										fieldWithPath("message").description("에러 메시지")
+								)
+						));
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 역할 변경 API")
+	class UpdateMemberRole {
+
+		@Nested
+		@DisplayName("성공 케이스")
+		class Success {
+
+			@Test
+			@DisplayName("신규 회원인 경우 일반 회원으로 변경한다")
+			public void updateNewMemberToMember() throws Exception {
+
+				//given
+				Member buyer = memberRepository.save(MemberFixture.createMember1());
+
+				CustomUserDetails userDetails = CustomUserDetails.from(buyer);
+
+				//when & then
+				mockMvc.perform(post("/api/members/role")
+								.with(authentication(new UsernamePasswordAuthenticationToken(
+										userDetails, null, userDetails.getAuthorities()
+								))))
+						.andExpect(status().isOk())
+						.andDo(document("member/update-member-role",
 								responseFields(
 										fieldWithPath("code").description("상태 코드"),
 										fieldWithPath("message").description("에러 메시지")


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 최초 사용자 역할 변경 기능

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 최초 온보딩 화면을 위한 NEW_MEMBER 에서 일반 회원으로 변경하기 위한 API 입니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #292 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?