### PR TITLE
[DP-295] fix: 구매 내역 조회 시 리뷰 여부 반환

### DIFF
--- a/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/product/repository/ProductCustomRepositoryImpl.java
@@ -63,7 +63,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 				))
 				.from(product)
 				.join(mobileData).on(mobileData.id.eq(product.itemId))
-				.where(isActiveProduct(),
+				.where(product.itemType.eq(ItemType.MOBILE_DATA),
+						isActiveProduct(),
 						mobileDataCondition(cursorId, productSortOption),
 						eqDataAmount(dataAmount)
 				)
@@ -134,7 +135,8 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 												.where(productImageSub.wifiId.eq(wifi.id))
 								))
 				)
-				.where(isActiveProduct(),
+				.where(product.itemType.eq(ItemType.WIFI),
+						isActiveProduct(),
 						wifiCursorCondition(cursorId, productSortOption, latitude, longitude),
 						isOpenNow(isOpen)
 				)

--- a/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
+++ b/src/main/java/com/dapanda/trade/dto/PurchaseHistorySummary.java
@@ -16,5 +16,6 @@ public class PurchaseHistorySummary {
 	private String title; // 와이파이 상품
 	private String productImageUrl; // 와이파이 상품
 	private Integer timeAmount; // 와이파이 상품
+	private boolean isReviewed;
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
@@ -4,8 +4,10 @@ import static com.dapanda.product.entity.QMobileData.mobileData;
 import static com.dapanda.product.entity.QProduct.product;
 import static com.dapanda.product.entity.QProductImage.productImage;
 import static com.dapanda.product.entity.QWifi.wifi;
+import static com.dapanda.review.entity.QReview.review;
 import static com.dapanda.trade.entity.QTrade.trade;
 import static com.dapanda.trade.entity.QTradeDetails.tradeDetails;
+import static com.querydsl.core.types.dsl.Expressions.asBoolean;
 
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.product.entity.ItemType;
@@ -42,6 +44,7 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 						wifi.title.coalesce(""),
 						productImage.imageUrl.coalesce(""),
 						trade.timeAmount.coalesce(0),
+						asBoolean(review.id.isNotNull()),
 						trade.createdAt
 				))
 				.from(trade)
@@ -58,6 +61,9 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 												.from(productImageSub)
 												.where(productImageSub.wifiId.eq(wifi.id))
 								))
+				)
+				.leftJoin(review).on(
+						review.trade.eq(trade)
 				)
 				.where(eqMemberId(memberId),
 						ltCursorId(cursorId),

--- a/src/test/java/com/dapanda/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/dapanda/chat/controller/ChatControllerTest.java
@@ -1,6 +1,5 @@
 package com.dapanda.chat.controller;
 
-import com.dapanda.RedisTestContainerConfig;
 import static com.dapanda.TestConstants.Pagination.CHAT_MESSAGE_HISTORY_DEFAULT_SIZE;
 import static com.dapanda.TestConstants.Pagination.DEFAULT_SIZE_2;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +10,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -137,7 +135,8 @@ class ChatControllerTest {
 						.andExpect(jsonPath("$.data.chatRoomId").exists())
 						.andDo(document("chat/create-chat-room",
 										pathParameters(
-												parameterWithName("productId").description("채팅방을 생성할 상품의 아이디 (필수)")
+												parameterWithName("productId").description(
+														"채팅방을 생성할 상품의 아이디 (필수)")
 										),
 										responseFields(
 												fieldWithPath("code").description("상태 코드"),
@@ -176,7 +175,8 @@ class ChatControllerTest {
 						.andExpect(jsonPath("$.data.chatRoomId").value(chatRoom.getId()))
 						.andDo(document("chat/chat-room-already-exist",
 										pathParameters(
-												parameterWithName("productId").description("채팅방을 생성할 상품의 아이디 (필수)")
+												parameterWithName("productId").description(
+														"채팅방을 생성할 상품의 아이디 (필수)")
 										),
 										responseFields(
 												fieldWithPath("code").description("상태 코드"),
@@ -208,7 +208,8 @@ class ChatControllerTest {
 
 				CustomUserDetails userDetails = CustomUserDetails.from(buyer);
 
-				List<MobileData> mobileDataList = mobileDataRepository.saveAll(MobileDataFixture.createMobileDataList());
+				List<MobileData> mobileDataList = mobileDataRepository.saveAll(
+						MobileDataFixture.createMobileDataList());
 
 				List<Product> productList = productRepository.saveAll(
 						ProductFixture.createProductList(seller, mobileDataList,
@@ -310,7 +311,6 @@ class ChatControllerTest {
 								.with(authentication(new UsernamePasswordAuthenticationToken(
 										userDetails, null, userDetails.getAuthorities()
 								))))
-						.andDo(print())
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
@@ -546,8 +546,6 @@ class ChatControllerTest {
 
 				ChatMessage lastChatMessage = chatMessageList.get(chatMessageList.size() - 1);
 
-				System.out.println("lastChatMessage = " + lastChatMessage.getMember());
-
 				//when & then
 				mockMvc.perform(post("/api/chat-messages/{chatMessageId}/read-status",
 								lastChatMessage.getId())
@@ -555,7 +553,6 @@ class ChatControllerTest {
 								.with(authentication(new UsernamePasswordAuthenticationToken(
 										userDetails, null, userDetails.getAuthorities()
 								))))
-						.andDo(print())
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))

--- a/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/dapanda/payment/controller/PaymentControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -269,7 +268,6 @@ class PaymentControllerTest {
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
-						.andDo(print())
 						.andDo(document("payments/charge-cash",
 								requestFields(
 										fieldWithPath("paymentKey").description("토스 결제 키"),
@@ -403,7 +401,6 @@ class PaymentControllerTest {
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
 						.andExpect(jsonPath("$.data.refundPrice").value(response.getRefundPrice()))
 						.andExpect(jsonPath("$.data.remainCash").value(response.getRemainCash()))
-						.andDo(print())
 						.andDo(document("payments/refund-cash",
 								requestFields(
 										fieldWithPath("requestId").description(

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -1268,6 +1268,7 @@ class TradeControllerTest {
 						.andExpect(jsonPath("$.data.trades.data[0].title").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].productImageUrl").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].timeAmount").exists())
+						.andExpect(jsonPath("$.data.trades.data[0].isReviewed").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].createdAt").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo.size").exists())
@@ -1302,6 +1303,8 @@ class TradeControllerTest {
 												"거래 상품 대표 이미지 URL (와이파이)"),
 										fieldWithPath("data.trades.data[].timeAmount").description(
 												"거래 시간양 (와이파이)"),
+										fieldWithPath("data.trades.data[].isReviewed").description(
+												"리뷰 작성 여부"),
 										fieldWithPath("data.trades.data[].createdAt").description(
 												"거래 생성 시간"),
 										fieldWithPath("data.trades.pageInfo").description("페이지 정보"),

--- a/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/dapanda/trade/controller/TradeControllerTest.java
@@ -16,7 +16,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -1045,7 +1044,6 @@ class TradeControllerTest {
 										userDetails, null, userDetails.getAuthorities()
 								)))
 						)
-						.andDo(print())
 						.andExpect(status().isOk())
 						.andExpect(jsonPath("$.code").value(ResultCode.SUCCESS.getCode()))
 						.andExpect(jsonPath("$.message").value(ResultCode.SUCCESS.getMessage()))
@@ -1268,13 +1266,12 @@ class TradeControllerTest {
 						.andExpect(jsonPath("$.data.trades.data[0].title").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].productImageUrl").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].timeAmount").exists())
-						.andExpect(jsonPath("$.data.trades.data[0].isReviewed").exists())
+						.andExpect(jsonPath("$.data.trades.data[0].reviewed").exists())
 						.andExpect(jsonPath("$.data.trades.data[0].createdAt").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo.size").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo.hasNext").exists())
 						.andExpect(jsonPath("$.data.trades.pageInfo.nextCursorId").exists())
-						.andDo(print())
 						.andDo(document("trade/get-trade-purchase-history",
 								queryParameters(
 										parameterWithName("cursorId").description("커서 아이디 (선택)")
@@ -1303,7 +1300,7 @@ class TradeControllerTest {
 												"거래 상품 대표 이미지 URL (와이파이)"),
 										fieldWithPath("data.trades.data[].timeAmount").description(
 												"거래 시간양 (와이파이)"),
-										fieldWithPath("data.trades.data[].isReviewed").description(
+										fieldWithPath("data.trades.data[].reviewed").description(
 												"리뷰 작성 여부"),
 										fieldWithPath("data.trades.data[].createdAt").description(
 												"거래 생성 시간"),
@@ -1394,7 +1391,6 @@ class TradeControllerTest {
 										"$.data.cashHistorySummary.data[0].classification").exists())
 						.andExpect(jsonPath("$.data.cashHistorySummary.data[0].createdAt").exists())
 						.andExpect(jsonPath("$.data.cashHistorySummary.pageInfo").exists())
-						.andDo(print())
 						.andDo(document("trade/get-cash-history",
 								queryParameters(
 										parameterWithName("cursorId").description("커서 아이디 (선택)")

--- a/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/dapanda/trade/service/TradeServiceTest.java
@@ -747,6 +747,7 @@ class TradeServiceTest {
 						TITLE,
 						PROFILE_IMAGE_URL,
 						10,
+						true,
 						trade1.getCreatedAt()
 				);
 
@@ -758,6 +759,7 @@ class TradeServiceTest {
 						TITLE + 1,
 						PROFILE_IMAGE_URL,
 						10,
+						false,
 						trade2.getCreatedAt()
 				);
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 구매 내역 조회 시 리뷰 여부 반환
- 상품 목록 조회 필터링 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #297 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?