### PR TITLE
[DP-311] fix: application.yml 및 start.sh에 타임존 설정 반영

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,7 +16,7 @@ sudo timedatectl set-timezone Asia/Seoul
 
 # 앱 실행
 echo "Starting $APP_NAME with prod profile..."
-nohup java -jar "$APP_DIR/$APP_NAME" --spring.profiles.active=prod > /dev/null 2>&1 &
+nohup java -Duser.timezone=Asia/Seoul -jar "$APP_DIR/$APP_NAME" --spring.profiles.active=prod > /dev/null 2>&1 &
 
 # ===== CloudWatch Agent 설치 여부 확인 후 설치 =====
 echo "Checking CloudWatch Agent installation..."

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,12 @@ server:
 spring:
   profiles:
     active: dev
+
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    time-zone: Asia/Seoul
+
   security:
     oauth2:
       client:
@@ -47,6 +53,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
 
   cache:
     type: redis


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 설정되지 않은 JVM 타임존으로 인한 타임스탬프 UTC 직렬화 문제 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 배포 환경에서 시간이 +09:00 또는 -09:00으로 잘못 표시되는 문제가 있었습니다.
조사해 보니 서버와 DB는 KST로 맞춰져 있었지만, JVM 기본 시간대가 UTC로 설정되어 Jackson 직렬화 시 잘못된 타임존이 적용되는 것이 원인이었습니다.
서버에서 JVM 옵션과 DB 세션 타임존을 직접 수정해 정상 동작을 확인한 후, 이 내용을 반영해 `start.sh` 스크립트와 `application.yml`을 업데이트했습니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #311 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?