### PR TITLE
[DP-339] fix: 알림을 보내기 전에 와이파이 상품의 거래 유효성을 검사하도록 수정

### DIFF
--- a/src/main/java/com/dapanda/alarm/scheduler/WifiTradeNotificationScheduler.java
+++ b/src/main/java/com/dapanda/alarm/scheduler/WifiTradeNotificationScheduler.java
@@ -1,14 +1,13 @@
 package com.dapanda.alarm.scheduler;
 
 import com.dapanda.alarm.event.WifiTradeEvent;
+import com.dapanda.trade.repository.TradeRepository;
+import java.time.*;
+import java.util.concurrent.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-import java.time.LocalTime;
-import java.util.concurrent.*;
 
 @Slf4j
 @Service
@@ -17,6 +16,7 @@ public class WifiTradeNotificationScheduler {
 
 	private final ApplicationEventPublisher eventPublisher;
 	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
+	private final TradeRepository tradeRepository;
 
 	public void scheduleNotification(Long tradeId, Long memberId, LocalTime startTime,
 			LocalTime endTime) {
@@ -48,15 +48,32 @@ public class WifiTradeNotificationScheduler {
 	private void publishStartNow(Long tradeId, Long memberId, LocalTime startTime,
 			LocalTime endTime) {
 
-		log.info("와이파이 시작 알림 발행 -> memberId: {}, tradeId: {}", memberId, tradeId);
-		eventPublisher.publishEvent(WifiTradeEvent.createStartEvent(tradeId, memberId, startTime, endTime));
+		if (isTodayTrade(tradeId)) {
+			log.info("와이파이 시작 알림 발행 -> memberId: {}, tradeId: {}", memberId, tradeId);
+			eventPublisher.publishEvent(
+					WifiTradeEvent.createStartEvent(tradeId, memberId, startTime, endTime));
+		} else {
+			log.info("유효하지 않은(오늘이 아닌) 거래 시작 알림입니다. tradeId={}", tradeId);
+		}
 	}
 
 	private void publishEndNow(Long tradeId, Long memberId, LocalTime startTime,
 			LocalTime endTime) {
 
-		log.info("와이파이 종료 알림 발행 -> memberId: {}, tradeId: {}", memberId, tradeId);
-		eventPublisher.publishEvent(WifiTradeEvent.createEndEvent(tradeId, memberId, startTime, endTime));
+		if (isTodayTrade(tradeId)) {
+			log.info("와이파이 종료 알림 발행 -> memberId: {}, tradeId: {}", memberId, tradeId);
+			eventPublisher.publishEvent(
+					WifiTradeEvent.createEndEvent(tradeId, memberId, startTime, endTime));
+		} else {
+			log.info("유효하지 않은(오늘이 아닌) 거래 알림입니다. tradeId={}", tradeId);
+		}
+	}
+
+	private boolean isTodayTrade(Long tradeId) {
+
+		LocalDate tradeDate = tradeRepository.findTradeDateById(tradeId);
+
+		return tradeDate != null && tradeDate.equals(LocalDate.now());
 	}
 
 }

--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepository.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepository.java
@@ -2,6 +2,7 @@ package com.dapanda.trade.repository;
 
 import com.dapanda.common.dto.response.CursorPageResponse;
 import com.dapanda.trade.dto.*;
+import java.time.LocalDate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,5 +19,7 @@ public interface TradeCustomRepository {
 	public CashHistoryMonthlySummary calculateMonthlySummary(Long memberId, int year, int month);
 
 	boolean existsByProductId(Long productId);
+
+	LocalDate findTradeDateById(Long tradeId);
 
 }

--- a/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
+++ b/src/main/java/com/dapanda/trade/repository/TradeCustomRepositoryImpl.java
@@ -270,4 +270,17 @@ public class TradeCustomRepositoryImpl implements TradeCustomRepository {
 
 		return count != null;
 	}
+
+	@Override
+	public LocalDate findTradeDateById(Long tradeId) {
+
+		LocalDateTime createdAt = queryFactory
+				.select(trade.createdAt)
+				.from(trade)
+				.where(trade.id.eq(tradeId))
+				.fetchOne();
+
+		return createdAt != null ? createdAt.toLocalDate() : null;
+	}
+
 }

--- a/src/test/java/com/dapanda/alarm/scheduler/WifiTradeNotificationSchedulerTest.java
+++ b/src/test/java/com/dapanda/alarm/scheduler/WifiTradeNotificationSchedulerTest.java
@@ -1,17 +1,17 @@
 package com.dapanda.alarm.scheduler;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import com.dapanda.alarm.event.WifiTradeEvent;
+import com.dapanda.trade.repository.TradeRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-
-import java.time.LocalTime;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("거래 알림 스케줄러 테스트")
@@ -19,12 +19,14 @@ class WifiTradeNotificationSchedulerTest {
 
 	@Mock
 	ApplicationEventPublisher eventPublisher;
+	@Mock
+	TradeRepository tradeRepository;
 
 	WifiTradeNotificationScheduler scheduler;
 
 	@BeforeEach
 	void setUp() {
-		scheduler = new WifiTradeNotificationScheduler(eventPublisher);
+		scheduler = new WifiTradeNotificationScheduler(eventPublisher, tradeRepository);
 	}
 
 	@Test
@@ -38,7 +40,9 @@ class WifiTradeNotificationSchedulerTest {
 		LocalTime endTime = startTime.plusMinutes(30);
 
 		// when
-		scheduler.scheduleNotification(memberId, tradeId, startTime, endTime);
+		when(tradeRepository.findTradeDateById(tradeId))
+				.thenReturn(LocalDate.now());
+		scheduler.scheduleNotification(tradeId, memberId, startTime, endTime);
 
 		// then: delay 이후에 이벤트가 발행됐는지 확인
 		Thread.sleep(1500); // 1.5초 기다림


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 알림을 보내기 전에 와이파이 상품의 거래 유효성을 검사하도록 수정하였습니다.
- Trade의 createdAt을 가져와서 오늘의 날짜와 Date를 비교하고 같지 않다면 알림을 패스합니다.

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #340 

## ✅ 체크리스트

- PR 템플릿에 맞추어 작성했나요?
- PR에 적절한 라벨을 선택했나요?
- Jira 티켓 아이디가 PR 제목과또는 커밋 메시지에 포함되어 있나요?
- 변경 내용에 대한 테스트를 진행했나요?
- `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
- 로컬 서버에서 정상 동작을 확인했나요?
- 불필요한 코드는 삭제했나요?